### PR TITLE
Amend api docs to indicate there are multiple endpoints

### DIFF
--- a/docs/api/introduction/api-endpoints.md
+++ b/docs/api/introduction/api-endpoints.md
@@ -13,11 +13,11 @@ description: Zilliqa API Endpoints
 You can use the following endpoints to interact with the Zilliqa API, either via EVM or the
 [Zilliqa JSON API](./api-introduction.md).
 
-| Chain(s)              | Zilliqa API Chain Id | EVM Chain Id | URL(s)                                                                                       |
-| --------------------- | -------------------- | ------------ | -------------------------------------------------------------------------------------------- |
-| **Zilliqa mainnet**   | 1                    | 32769        | [https://api.zilliqa.com/](https://api.zilliqa.com/)                                         |
-| **Developer testnet** | 333                  | 33101        | [https://dev-api.zilliqa.com/](https://dev-api.zilliqa.com/)                                 |
-| **Isolated server**   | 222                  | 32990        | [https://zilliqa-isolated-server.zilliqa.com/](https://zilliqa-isolated-server.zilliqa.com/) |
+| Chain(s)              | Zilliqa API Chain Id | EVM Chain Id | URL(s)                                                                                                                                                      |
+| --------------------- | -------------------- | ------------ |-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Zilliqa mainnet**   | 1                    | 32769        | [https://api.zilliqa.com/](https://api.zilliqa.com/) or [http://evm-api-filters.zilliqa.com/](http://evm-api-filters.zilliqa.com/) (if using eth_subscribe) |
+| **Developer testnet** | 333                  | 33101        | [https://dev-api.zilliqa.com/](https://dev-api.zilliqa.com/)                                                                                                |
+| **Isolated server**   | 222                  | 32990        | [https://zilliqa-isolated-server.zilliqa.com/](https://zilliqa-isolated-server.zilliqa.com/)                                                                |
 
 You can use the following block explorers for the various networks
 


### PR DESCRIPTION
eth_subscribe is stateful and so needs to hit the same endpoint successive times.
To this end the current solution is that you need to use http://evm-api-filters.zilliqa.com/ on mainnet for example if you want to guarantee this.
