### PR TITLE
DEVOPS-833: migrate bazel cache to GCS

### DIFF
--- a/.github/workflows/ci-on-merge-main-or-release.yml
+++ b/.github/workflows/ci-on-merge-main-or-release.yml
@@ -32,6 +32,22 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
+          service_account: "${{ secrets.GCP_PRD_GITHUB_SA_GCS_CACHE }}"
+          create_credentials_file: true
+
+      - name: Configure bazel GCS cache
+        run: |
+          export BAZEL_REMOTE_CACHE_CREDENTIALS_JSON='${{ steps.auth.outputs.credentials_file_path }}'
+          export BAZEL_REMOTE_CACHE_ENDPOINT='${{ vars.BAZEL_REMOTE_CACHE_ENDPOINT }}'
+          python config/gcp_cs_cache.py
+        shell: bash
+
       #### BEGIN PRODUCT CHANGES EVALUATION ####
       - name: Get changed files
         id: changed-files
@@ -96,15 +112,6 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_SECRET_KET_MANIFESTS }}
 
-      - name: Bazel cache
-        id: cache-bazel-debug
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel', 'workflows') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-
-
       - name: Get tag version
         id: get-version
         run: |
@@ -146,17 +153,17 @@ jobs:
       - name: "Build and push Docker - developer-portal - staging"
         if: github.ref_name == env.DEFAULT_BRANCH && github.event_name != 'release' && steps.project-changed.outputs.developer-portal == 'true'
         run: |
-          bazelisk run --test_output=all --keep_going --disk_cache=~/.cache/bazel/ //products/developer-portal:push_image_staging
+          bazelisk run --test_output=all --keep_going //products/developer-portal:push_image_staging
 
       - name: "Build and push Docker - neo-savant - staging"
         if: github.ref_name == env.DEFAULT_BRANCH && github.event_name != 'release' && steps.project-changed.outputs.neo-savant == 'true'
         run: |
-          bazelisk run --test_output=all --keep_going --disk_cache=~/.cache/bazel/ //products/neo-savant:push_image_staging
+          bazelisk run --test_output=all --keep_going //products/neo-savant:push_image_staging
 
       - name: "Build and push Docker - devex - staging"
         if: github.ref_name == env.DEFAULT_BRANCH && github.event_name != 'release' && steps.project-changed.outputs.devex == 'true'
         run: |
-          bazelisk run --test_output=all --keep_going --disk_cache=~/.cache/bazel/ //products/devex:push_image_staging
+          bazelisk run --test_output=all --keep_going //products/devex:push_image_staging
 
       - name: Configure AWS Credentials - production
         if: github.event_name == 'release' && github.event.action == 'created'
@@ -193,17 +200,17 @@ jobs:
       - name: "Build and push Docker - developer-portal - production"
         if: github.event_name == 'release' && github.event.action == 'created' && steps.project-changed.outputs.developer-portal == 'true'
         run: |
-          bazelisk run --test_output=all --keep_going --disk_cache=~/.cache/bazel/ //products/developer-portal:push_image_production
+          bazelisk run --test_output=all --keep_going //products/developer-portal:push_image_production
 
       - name: "Build and push Docker - neo-savant - production"
         if: github.event_name == 'release' && github.event.action == 'created' && steps.project-changed.outputs.neo-savant == 'true'
         run: |
-          bazelisk run --test_output=all --keep_going --disk_cache=~/.cache/bazel/ //products/neo-savant:push_image_production
+          bazelisk run --test_output=all --keep_going //products/neo-savant:push_image_production
 
       - name: "Build and push Docker - devex - production"
         if: github.event_name == 'release' && github.event.action == 'created' && steps.project-changed.outputs.devex == 'true'
         run: |
-          bazelisk run --test_output=all --keep_going --disk_cache=~/.cache/bazel/ //products/devex:push_image_production
+          bazelisk run --test_output=all --keep_going //products/devex:push_image_production
 
       ### BEGIN DEPLOYMENT STAGES
       - name: "Create application.bzl"

--- a/.github/workflows/ci-on-pr-bazel-test-mac.yml
+++ b/.github/workflows/ci-on-pr-bazel-test-mac.yml
@@ -17,6 +17,9 @@ jobs:
   build-debug:
     runs-on: macos-12
     name: "Bazel Debug Build"
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -24,17 +27,26 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Bazel cache
-        id: cache-bazel-debug
-        uses: actions/cache@v3.0.4
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
         with:
-          path: ~/.cache/bazel/
-          key: ${{ runner.os }}-bazel-debug
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
+          service_account: "${{ secrets.GCP_PRD_GITHUB_SA_GCS_CACHE }}"
+          create_credentials_file: true
+
+      - name: Configure bazel GCS cache
+        run: |
+          export BAZEL_REMOTE_CACHE_CREDENTIALS_JSON='${{ steps.auth.outputs.credentials_file_path }}'
+          export BAZEL_REMOTE_CACHE_ENDPOINT='${{ vars.BAZEL_REMOTE_CACHE_ENDPOINT }}'
+          python config/gcp_cs_cache.py
+        shell: bash
 
       - name: "Building debug"
         run: |
-          bazelisk build --keep_going --disk_cache=~/.cache/bazel/  //...
+          bazelisk build --keep_going //...
 
       - name: "Running tests"
         run: |
-          bazelisk test --test_output=all --keep_going --disk_cache=~/.cache/bazel/ //...
+          bazelisk test --test_output=all //...

--- a/.github/workflows/ci-on-pr-bazel-test-ubuntu-22.04.yml
+++ b/.github/workflows/ci-on-pr-bazel-test-ubuntu-22.04.yml
@@ -17,6 +17,9 @@ jobs:
   build-debug:
     runs-on: ubuntu-22.04
     name: "Bazel Debug Build"
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -24,17 +27,26 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Bazel cache
-        id: cache-bazel-debug
-        uses: actions/cache@v3.0.4
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
         with:
-          path: ~/.cache/bazel/
-          key: ${{ runner.os }}-bazel-debug
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
+          service_account: "${{ secrets.GCP_PRD_GITHUB_SA_GCS_CACHE }}"
+          create_credentials_file: true
+
+      - name: Configure bazel GCS cache
+        run: |
+          export BAZEL_REMOTE_CACHE_CREDENTIALS_JSON='${{ steps.auth.outputs.credentials_file_path }}'
+          export BAZEL_REMOTE_CACHE_ENDPOINT='${{ vars.BAZEL_REMOTE_CACHE_ENDPOINT }}'
+          python config/gcp_cs_cache.py
+        shell: bash
 
       - name: "Building debug"
         run: |
-          bazelisk build --keep_going --disk_cache=~/.cache/bazel/  //...
+          bazelisk build --keep_going //...
 
       - name: "Running tests"
         run: |
-          bazelisk test --test_output=all --keep_going --disk_cache=~/.cache/bazel/ //...
+          bazelisk test --test_output=all --keep_going //...

--- a/config/gcp_cs_cache.py
+++ b/config/gcp_cs_cache.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+import argparse
+import os
+
+parser = argparse.ArgumentParser(description="Configure Bazel remote cache.")
+parser.add_argument("--endpoint", type=str, help="Remote cache endpoint URL")
+parser.add_argument("--credentials", type=str, help="Path to JSON secret key file")
+args = parser.parse_args()
+
+# Get values from command-line arguments or environment variables
+ENDPOINT = args.endpoint or os.environ.get("BAZEL_REMOTE_CACHE_ENDPOINT")
+
+CREDENTIALS_JSON = args.credentials or os.environ.get(
+    "BAZEL_REMOTE_CACHE_CREDENTIALS_JSON"
+)
+
+with open(".bazelrc.configure", "w") as fb:
+    fb.write("build --remote_cache={}\n".format(ENDPOINT))
+    fb.write("build --google_credentials={}\n".format(CREDENTIALS_JSON))


### PR DESCRIPTION
This PR introduces the remote cache to bazel to solve the size limit issue we were facing on the default GHA cache (10GB) and speed up the overall monorepo build process.
It uses a Google Cloud Storage bucket hosted on the GCP Zilliqa organization as cache storage.
The integration has been built leveraging oicd and federated workload identities. No static and insecure keys have been sprawl across.
The required configuration parameters workload_identity_provider and google service account id have been exposed as Organization environment variable for a simpler integration with the multiple bazel worklaods.
The authentication to google has been managed with the GHA google-github-actions/auth@v1.