### PR TITLE
US-317: PDT - Update listen error handling + update deps

### DIFF
--- a/products/pdt/Cargo.lock
+++ b/products/pdt/Cargo.lock
@@ -245,12 +245,12 @@ dependencies = [
  "aws-http",
  "aws-sdk-sso",
  "aws-sdk-sts",
- "aws-smithy-async",
+ "aws-smithy-async 0.56.1",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.56.1",
  "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types",
+ "aws-smithy-types 0.56.1",
  "aws-types",
  "bytes",
  "fastrand",
@@ -271,8 +271,8 @@ version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a66ac8ef5fa9cf01c2d999f39d16812e90ec1467bd382cbbb74ba23ea86201"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
+ "aws-smithy-async 0.56.1",
+ "aws-smithy-types 0.56.1",
  "fastrand",
  "tokio",
  "tracing",
@@ -286,8 +286,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e626370f9ba806ae4c439e49675fd871f5767b093075cdf4fef16cac42ba900"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.56.1",
+ "aws-smithy-types 0.56.1",
  "aws-types",
  "bytes",
  "http",
@@ -307,11 +307,11 @@ dependencies = [
  "aws-credential-types",
  "aws-http",
  "aws-sigv4",
- "aws-smithy-async",
+ "aws-smithy-async 0.56.1",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-http 0.56.1",
+ "aws-smithy-runtime-api 0.56.1",
+ "aws-smithy-types 0.56.1",
  "aws-types",
  "fastrand",
  "http",
@@ -322,23 +322,23 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73018483d9cb78e1a0d4dcbc94327b01d532e7cb28f26c5bceff97f8f0e4c6eb"
+checksum = "42f7a233b27af6e70094eafd43d9ee11da6e78eb2c1a31e5a7de737b782c627d"
 dependencies = [
  "aws-credential-types",
  "aws-http",
  "aws-runtime",
  "aws-sigv4",
- "aws-smithy-async",
+ "aws-smithy-async 0.56.1",
  "aws-smithy-checksums",
  "aws-smithy-client",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.56.1",
  "aws-smithy-json",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 0.56.1",
+ "aws-smithy-types 0.56.1",
  "aws-smithy-xml",
  "aws-types",
  "bytes",
@@ -361,13 +361,13 @@ dependencies = [
  "aws-credential-types",
  "aws-http",
  "aws-runtime",
- "aws-smithy-async",
+ "aws-smithy-async 0.56.1",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.56.1",
  "aws-smithy-json",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 0.56.1",
+ "aws-smithy-types 0.56.1",
  "aws-types",
  "bytes",
  "http",
@@ -385,14 +385,14 @@ dependencies = [
  "aws-credential-types",
  "aws-http",
  "aws-runtime",
- "aws-smithy-async",
+ "aws-smithy-async 0.56.1",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.56.1",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 0.56.1",
+ "aws-smithy-types 0.56.1",
  "aws-smithy-xml",
  "aws-types",
  "http",
@@ -408,8 +408,8 @@ checksum = "54bdd56437a3f6bd3f5d16d5ba0532e90e6c9371b8274cd97a55a2f2c3e44efb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-async 0.56.1",
+ "aws-smithy-http 0.56.1",
  "aws-types",
  "http",
  "tracing",
@@ -422,7 +422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7b28f4910bb956b7ab320b62e98096402354eca976c587d1eeccd523d9bac03"
 dependencies = [
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.56.1",
  "bytes",
  "form_urlencoded",
  "hex",
@@ -449,13 +449,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-async"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b65a284265d3eec6cc9f1daef2d0cc3b78684b712cb6c7f1d0f665456b7604"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "aws-smithy-checksums"
 version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb15946af1b8d3beeff53ad991d9bff68ac22426b6d40372b958a75fa61eaed"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.56.1",
+ "aws-smithy-types 0.56.1",
  "bytes",
  "crc32c",
  "crc32fast",
@@ -475,10 +486,10 @@ version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c27b2756264c82f830a91cb4d2d485b2d19ad5bea476d9a966e03d27f27ba59a"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-async 0.56.1",
+ "aws-smithy-http 0.56.1",
  "aws-smithy-http-tower",
- "aws-smithy-types",
+ "aws-smithy-types 0.56.1",
  "bytes",
  "fastrand",
  "http",
@@ -499,7 +510,7 @@ version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "850233feab37b591b7377fd52063aa37af615687f5896807abe7f49bd4e1d25b"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.56.1",
  "bytes",
  "crc32fast",
 ]
@@ -511,7 +522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54cdcf365d8eee60686885f750a34c190e513677db58bbc466c44c588abf4199"
 dependencies = [
  "aws-smithy-eventstream",
- "aws-smithy-types",
+ "aws-smithy-types 0.56.1",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -528,13 +539,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-http"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715aeb61fb743848d5d398ce6fb1259f5eba5e13dceec5d5064cada1a181d38d"
+dependencies = [
+ "aws-smithy-runtime-api 0.57.1",
+ "aws-smithy-types 0.57.1",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-http-tower"
 version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822de399d0ce62829a69dfa8c5cd08efdbe61a7426b953e2268f8b8b52a607bd"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.56.1",
+ "aws-smithy-types 0.56.1",
  "bytes",
  "http",
  "http-body",
@@ -549,7 +580,7 @@ version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1e7ab8fa7ad10c193af7ae56d2420989e9f4758bf03601a342573333ea34f"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.56.1",
 ]
 
 [[package]]
@@ -558,7 +589,7 @@ version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28556a3902091c1f768a34f6c998028921bdab8d47d92586f363f14a4a32d047"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.56.1",
  "urlencoding",
 ]
 
@@ -568,11 +599,11 @@ version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "745e096b3553e7e0f40622aa04971ce52765af82bebdeeac53aa6fc82fe801e6"
 dependencies = [
- "aws-smithy-async",
+ "aws-smithy-async 0.56.1",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-http 0.56.1",
+ "aws-smithy-runtime-api 0.56.1",
+ "aws-smithy-types 0.56.1",
  "bytes",
  "fastrand",
  "http",
@@ -590,11 +621,26 @@ version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93d0ae0c9cfd57944e9711ea610b48a963fb174a53aabacc08c5794a594b1d02"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-async 0.56.1",
+ "aws-smithy-http 0.56.1",
+ "aws-smithy-types 0.56.1",
  "bytes",
  "http",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e27594c06f5b36e97d18ef26ed693f1d4c7167b9bbb544b3a9bb653f9f7035"
+dependencies = [
+ "aws-smithy-async 0.57.1",
+ "aws-smithy-types 0.57.1",
+ "bytes",
+ "http",
+ "pin-project-lite",
  "tokio",
  "tracing",
 ]
@@ -608,6 +654,27 @@ dependencies = [
  "base64-simd",
  "itoa",
  "num-integer",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d36f1723ed61e82094498e7283510fe21484b73c215c33874c81a84411b5bdc"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
  "ryu",
  "serde",
  "time",
@@ -629,10 +696,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85aa0451bf8af1bf22a4f028d5d28054507a14be43cb8ac0597a8471fba9edfe"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-async",
+ "aws-smithy-async 0.56.1",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.56.1",
+ "aws-smithy-types 0.56.1",
  "http",
  "rustc_version",
  "tracing",
@@ -1295,6 +1362,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,7 +1659,7 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde 0.4.0",
- "primitive-types 0.12.1",
+ "primitive-types 0.12.2",
  "scale-info",
  "uint",
 ]
@@ -1646,7 +1723,7 @@ dependencies = [
  "ethers-core",
  "ethers-etherscan",
  "eyre",
- "prettyplease 0.2.15",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -2101,32 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "gcp-bigquery-client"
-version = "0.16.7"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b02c1b8f8afc83e7a138506f008e904d3b29a497b2e50ac4e7d51b1697d6cbd"
-dependencies = [
- "async-stream",
- "async-trait",
- "dyn-clone",
- "hyper",
- "hyper-rustls",
- "log",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "time",
- "tokio",
- "tokio-stream",
- "url",
- "yup-oauth2",
-]
-
-[[package]]
-name = "gcp-bigquery-client"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e733661b482eda6e5bc43213d35976dc4f3a50d956c90f9dbd6785f2b0b1bed"
+checksum = "b0ce6fcbdaca0a4521a734f2bc7f2f6bd872fe40576e24f8bd0b05732c19a74f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3225,7 +3279,7 @@ dependencies = [
  "pdtlisten",
  "pdtparse",
  "pdtpsql",
- "primitive-types 0.11.1",
+ "primitive-types 0.12.2",
  "serde",
  "serde_json",
  "sqlx",
@@ -3241,12 +3295,12 @@ dependencies = [
  "async-trait",
  "base64 0.21.2",
  "clap",
- "gcp-bigquery-client 0.16.7",
+ "gcp-bigquery-client",
  "hex",
  "home",
  "pdtdb",
  "pdtlib",
- "primitive-types 0.11.1",
+ "primitive-types 0.12.2",
  "serde",
  "serde_json",
  "sha2",
@@ -3263,10 +3317,10 @@ dependencies = [
  "base64 0.21.2",
  "clap",
  "ethers",
- "gcp-bigquery-client 0.16.7",
+ "gcp-bigquery-client",
  "hex",
  "pdtlib",
- "primitive-types 0.11.1",
+ "primitive-types 0.12.2",
  "psql_derive",
  "serde",
  "serde_json",
@@ -3285,7 +3339,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-sig-auth",
- "aws-smithy-http",
+ "aws-smithy-http 0.57.1",
  "clap",
  "eth_trie",
  "eyre",
@@ -3315,7 +3369,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "ethers",
- "gcp-bigquery-client 0.17.0",
+ "gcp-bigquery-client",
  "jsonrpsee",
  "pdtbq",
  "pdtdb",
@@ -3515,6 +3569,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3525,16 +3585,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "prettyplease"
@@ -3560,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash 0.8.0",
  "impl-codec",
@@ -3626,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3636,44 +3686,44 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.5",
- "lazy_static",
+ "itertools 0.11.0",
  "log",
  "multimap",
+ "once_cell",
  "petgraph",
- "prettyplease 0.1.25",
+ "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.32",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
 dependencies = [
  "prost",
 ]
@@ -4856,13 +4906,15 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
+ "deranged",
  "itoa",
  "libc",
  "num_threads",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -4870,15 +4922,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]

--- a/products/pdt/pdt/Cargo.toml
+++ b/products/pdt/pdt/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.28.1", features = [
   "fs",
   "process",
 ] }
-primitive-types = { version = "0.11.1", features = ["serde"] }
+primitive-types = { version = "0.12.2", features = ["serde"] }
 anyhow = "1.0.71"
 clap = { version = "4.3.1", features = ["derive"] }
 async-trait = "0.1.68"

--- a/products/pdt/pdtbq/Cargo.toml
+++ b/products/pdt/pdtbq/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 [dependencies]
 pdtlib = { path = "../pdtlib" }
 pdtdb = { path = "../pdtdb" }
-primitive-types = { version = "0.11.1", features = ["serde"] }
+primitive-types = { version = "0.12.2", features = ["serde"] }
 clap = "4.2.4"
 tokio = "1.27.0"
-gcp-bigquery-client = "0.16.7"
+gcp-bigquery-client = "0.18.0"
 #gcp-bigquery-client = { path = "../../../gcp-bigquery-client" }
 anyhow = "1.0.71"
 serde = { version = "1.0.163", features = ["derive"] }

--- a/products/pdt/pdtdb/Cargo.toml
+++ b/products/pdt/pdtdb/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 [dependencies]
 pdtlib = { path = "../pdtlib" }
 psql_derive = { path = "psql_derive" }
-primitive-types = { version = "0.11.1", features = ["serde"] }
+primitive-types = { version = "0.12.2", features = ["serde"] }
 clap = "4.2.4"
 tokio = "1.27.0"
-gcp-bigquery-client = "0.16.7"
+gcp-bigquery-client = "0.18.0"
 #gcp-bigquery-client = { path = "../../../gcp-bigquery-client" }
 anyhow = "1.0.71"
 serde = { version = "1.0.163", features = ["derive"] }

--- a/products/pdt/pdtlib/Cargo.toml
+++ b/products/pdt/pdtlib/Cargo.toml
@@ -13,9 +13,9 @@ test = true
 [dependencies]
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 aws-config = "0.56.1"
-aws-sdk-s3 = "0.33.0"
+aws-sdk-s3 = "0.34.0"
 aws-sig-auth = "0.56.1"
-aws-smithy-http = "0.56.1"
+aws-smithy-http = "0.57.1"
 clap = { version = "4.3.0", features = ["derive"] }
 eth_trie = { git = "https://github.com/carver/eth-trie.rs" }
 eyre = "0.6.8"
@@ -23,7 +23,7 @@ futures = "0.3.28"
 hex = { version = "0.4.3", features = ["serde"] }
 indicatif = "0.17.3"
 primitive-types = { version = "0.11.1", features = ["serde"] }
-prost = "0.11.9"
+prost = "0.12.1"
 rlp = "0.5.2"
 rs-leveldb = "0.1.5"
 rustc-hex = "2.1.0"
@@ -42,4 +42,4 @@ tokio-stream = "0.1.14"
 walkdir = "2.3.3"
 
 [build-dependencies]
-prost-build = "0.11.6"
+prost-build = "0.12.1"

--- a/products/pdt/pdtlisten/Cargo.toml
+++ b/products/pdt/pdtlisten/Cargo.toml
@@ -15,7 +15,7 @@ pdtbq = { path = "../pdtbq" }
 pdtdb = { path = "../pdtdb" }
 pdtpsql = { path = "../pdtpsql" }
 sqlx = { version = "0.7.1", features = ["postgres", "runtime-tokio"] }
-gcp-bigquery-client = "0.17.0"
+gcp-bigquery-client = "0.18.0"
 
 tokio = { version = "1.28.1", features = [
   "macros",

--- a/products/pdt/pdtlisten/src/listener.rs
+++ b/products/pdt/pdtlisten/src/listener.rs
@@ -3,8 +3,8 @@ use ethers::{
     types::{Block, Transaction, U64},
 };
 
-use anyhow::Result;
-use async_stream::try_stream;
+use anyhow::{Ok, Result};
+use async_stream::stream;
 use pdtdb::values::ZILTransactionBody;
 use serde_json::{to_value, Value};
 use tokio::time::{interval, Duration};
@@ -45,21 +45,7 @@ async fn get_block_by_number(x: U64, provider: &Provider<Http>) -> Result<Block<
     // is not happy about.
     raw_block["nonce"] = serde_json::to_value("0x0000000000000000")?;
 
-    let mut block: Block<Transaction> = serde_json::from_value(raw_block)?;
-    while block.number.is_none() {
-        println!("{:?} is pending, looping", x);
-
-        // loop until the block is no longer pending
-        // the sleep duration is set arbitrarily.
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-        raw_block = provider
-            .request("eth_getBlockByNumber", [serialize(x), serialize(true)])
-            .await?;
-        raw_block["nonce"] = serde_json::to_value("0x0000000000000000")?;
-
-        block = serde_json::from_value(raw_block)?;
-    }
-    Ok(block)
+    Ok(serde_json::from_value(raw_block)?)
 }
 
 /// Fetches the most recent block number and compares against `last_seen_block_number` and retrieves all blocks in between
@@ -117,12 +103,20 @@ pub fn listen_blocks(
     provider: &Provider<Http>,
     from_block: Option<i64>,
 ) -> impl Stream<Item = Result<Vec<(Block<Transaction>, Vec<ZILTransactionBody>)>>> + '_ {
-    try_stream! {
+    stream! {
         let mut interval = interval(Duration::from_secs(15));
         let mut last_seen_block_number: Option<U64> = from_block.map(U64::from);
         loop {
             interval.tick().await;
-            yield get_block(provider, &mut last_seen_block_number).await?
+            yield get_block(provider, &mut last_seen_block_number).await.or_else(|err| {
+                // Handle known error
+                if err.to_string().contains("Tx Block does not exist") {
+                    println!("RPC does not have block yet, trying again later...");
+                    Ok(Vec::default())
+                } else {
+                    Err(err) // propagate the error
+                }
+            })
         }
     }
 }


### PR DESCRIPTION
The pods running in kubernetes keep on restarting because of `Tx Block does not exist` error thrown by the RPC that's used to collect the blocks. This is usually a momentary issue arising when the RPC is delayed. This can be solved through a graceful approach by retrieving the block on the next poll attempt