### PR TITLE
ZIL-5490: PDT Migrate Testnet Persistence to GCP 

### DIFF
--- a/products/pdt/cd/base/configmap.yaml
+++ b/products/pdt/cd/base/configmap.yaml
@@ -9,7 +9,7 @@ data:
   DATASET_ID_MAINNET: "ds_zq1_mainnet"
   NETWORK_TYPE_TESTNET: "testnet"
   NETWORK_TYPE_MAINNET: "mainnet"
-  NETWORK_TESTNET: "testnet-v925"
+  NETWORK_TESTNET: "testnet-v930rc9"
   NETWORK_MAINNET: "mainnet-v920"
   DOWNLOAD_DIR: "/data/download"
   UNPACK_DIR: "/data/download"

--- a/products/pdt/cd/overlays/staging/configmap.yaml
+++ b/products/pdt/cd/overlays/staging/configmap.yaml
@@ -9,7 +9,7 @@ data:
   DATASET_ID_MAINNET: "ds_zq1_mainnet"
   NETWORK_TYPE_TESTNET: "testnet"
   NETWORK_TYPE_MAINNET: "mainnet"
-  NETWORK_TESTNET: "testnet-v925"
+  NETWORK_TESTNET: "testnet-v930rc9"
   NETWORK_MAINNET: "mainnet-v920"
   DOWNLOAD_DIR: "/data/download"
   UNPACK_DIR: "/data/download"

--- a/products/pdt/pdt/src/main.rs
+++ b/products/pdt/pdt/src/main.rs
@@ -144,7 +144,7 @@ struct ListenOptions {
     buffer_size: usize,
 }
 
-const TESTNET_BUCKET: &str = "301978b4-0c0a-4b6b-ad7b-3a2f63c5182c";
+const TESTNET_BUCKET: &str = "zq1-testnet-persistence";
 const MAINNET_BUCKET: &str = "c5b68604-8540-4887-ad29-2ab9e680f997";
 
 const DEV_API_URL: &str = "https://dev-api.zilliqa.com/";


### PR DESCRIPTION
This affects only the cronjob run daily on the PDT, as it needs to download the persistence on a daily basis. The `listen` command and pods are unaffected.