### PR TITLE
DEVOPS-1040: correct vault for snapshot-api

### DIFF
--- a/products/governance-api/cd/overlays/production/secrets-app.yaml
+++ b/products/governance-api/cd/overlays/production/secrets-app.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: governance-api
   annotations:
-    zilliqa.com/autofill: "prj-d-prod-apps"
+    zilliqa.com/autofill: "prj-p-prod-apps"
 type: Opaque
 data:
   NODE_ENV: "governance-api/node_env"


### PR DESCRIPTION
Typo in the vault name for prod apps.