### PR TITLE
DEVOPS-1149: memory limits for devex, governance, zillion, neo-savant and isolated-server

### DIFF
--- a/products/developer-portal/cd/base/deployment.yaml
+++ b/products/developer-portal/cd/base/deployment.yaml
@@ -22,3 +22,8 @@ spec:
           name: developer-portal
           ports:
             - containerPort: 80
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              memory: 100Mi

--- a/products/devex/cd/base/deployment.yaml
+++ b/products/devex/cd/base/deployment.yaml
@@ -22,3 +22,8 @@ spec:
           name: devex
           ports:
             - containerPort: 80
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              memory: 100Mi

--- a/products/governance-api/cd/base/deployment.yaml
+++ b/products/governance-api/cd/base/deployment.yaml
@@ -22,6 +22,11 @@ spec:
           name: governance-api
           ports:
             - containerPort: 3000
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              memory: 300Mi
           env:
             - name: NODE_ENV
               valueFrom:

--- a/products/governance-snapshot/cd/base/deployment.yaml
+++ b/products/governance-snapshot/cd/base/deployment.yaml
@@ -22,6 +22,11 @@ spec:
           name: governance-snapshot
           ports:
             - containerPort: 80
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              memory: 100Mi
           volumeMounts:
           - mountPath: /usr/share/nginx/html/config.js
             name: governance-snapshot-config

--- a/products/neo-savant/cd/base/deployment.yaml
+++ b/products/neo-savant/cd/base/deployment.yaml
@@ -22,3 +22,8 @@ spec:
           name: neo-savant-ide
           ports:
             - containerPort: 80
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              memory: 100Mi

--- a/products/zillion/cd/base/deployment.yaml
+++ b/products/zillion/cd/base/deployment.yaml
@@ -22,6 +22,11 @@ spec:
           name: zillion
           ports:
             - containerPort: 80
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              memory: 100Mi
           volumeMounts:
             - mountPath: /usr/share/nginx/html/config.js
               name: zillion-config

--- a/products/zilliqa-isolated-server/cd/base/deployment.yaml
+++ b/products/zilliqa-isolated-server/cd/base/deployment.yaml
@@ -29,6 +29,11 @@ spec:
             - containerPort: 80
         - image: zilliqa-isolated-server
           name: zilliqa-isolated-server
+          resources:
+            limits:
+              memory: 400Mi
+            requests:
+              memory: 200Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:


### PR DESCRIPTION
Proposed request and memory limits for the following apps depending on their max. average memory usage:
- developer-portal (avg. max 20MB -> min: 100 MB max: 200 MB)
- devex (avg. max 20MB -> min: 100 MB max: 200 MB)
- governance-api (avg. max 200MB -> min: 300 MB max: 500 MB)
- governance-snapshot (avg. max 5MB -> min: 100 MB max: 200 MB)
- neo-savant-ide (avg. max 20MB -> min: 100 MB max: 200 MB)
- xcad-isolated-server (avg. max 100MB -> min: 200 MB max: 400 MB)
- zillion (avg. max 20MB -> min: 100 MB max: 200 MB)
- zilliqa-isolated-server (avg. max 100MB -> min: 200 MB max: 400 MB)