### PR TITLE
DEVOPS-1172: remove nucleus-server decomissioned url from neo-savant dev env

### DIFF
--- a/products/neo-savant/.env_dev
+++ b/products/neo-savant/.env_dev
@@ -3,4 +3,4 @@ VUE_APP_SCILLA_CHECKER_URL=http://localhost:4000/contract/check
 VUE_APP_ISOLATED_URL=http://localhost:5555/
 VUE_APP_ISOLATED_FAUCET=http://localhost:5556/
 VUE_APP_EXPLORER_URL=https://stg-devex.zilliqa.com/
-VUE_APP_TESTNET_FAUCET=https://nucleus-server.zilliqa.com/api/v1/run
+VUE_APP_FAUCET_URL=https://stg-dev-wallet.zilliqa.com/faucet


### PR DESCRIPTION
Since the domain https://nucleus-server.zilliqa.com/ was unreachable and no ECS service was running, we decomissioned the URL and propose to update the neo-savant env dev environment config (which is the only reference to the nucleus-server).