### PR TITLE
DEVOPS-1184: nginx custom config for dev-wallet

### DIFF
--- a/products/dev-wallet/Dockerfile
+++ b/products/dev-wallet/Dockerfile
@@ -8,5 +8,6 @@ RUN yarn build
 
 FROM nginx:stable-alpine as production-stage
 COPY --from=build-stage /app/build /usr/share/nginx/html
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/products/dev-wallet/nginx/default.conf
+++ b/products/dev-wallet/nginx/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Added a custom configuration for nginx to allow permalinks such as https://dev-wallet.zilliqa.com/faucet