### PR TITLE
ZIL-5548: Check sender contracts are registered on the ChainGateway

### DIFF
--- a/products/bridge/smart-contracts/contracts/core/ChainGateway.sol
+++ b/products/bridge/smart-contracts/contracts/core/ChainGateway.sol
@@ -7,5 +7,5 @@ import {Relayer} from "contracts/core/Relayer.sol";
 contract ChainGateway is Relayer, ChainDispatcherWithoutFees {
     constructor(
         address _validatorManager
-    ) ChainDispatcherWithoutFees(_validatorManager) {}
+    ) ChainDispatcherWithoutFees(_validatorManager) Relayer(msg.sender) {}
 }

--- a/products/bridge/smart-contracts/contracts/core/Registry.sol
+++ b/products/bridge/smart-contracts/contracts/core/Registry.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.20;
+
+abstract contract Registry {
+    mapping(address => bool) public registered;
+
+    error NotRegistered(address targetAddress);
+
+    modifier isRegistered(address target) {
+        if (!registered[target]) {
+            revert NotRegistered(target);
+        }
+        _;
+    }
+
+    function _register(address newTarget) internal {
+        registered[newTarget] = true;
+    }
+
+    function _unregister(address removeTarget) internal {
+        registered[removeTarget] = false;
+    }
+
+    function register(address newTarget) external virtual;
+
+    function unregister(address removeTarget) external virtual;
+}

--- a/products/bridge/smart-contracts/contracts/core/ShardGateway.sol
+++ b/products/bridge/smart-contracts/contracts/core/ShardGateway.sol
@@ -4,4 +4,6 @@ pragma solidity ^0.8.20;
 import {Relayer} from "contracts/core/Relayer.sol";
 import {ShardDispatcher} from "contracts/core/ShardDispatcher.sol";
 
-contract ShardGateway is Relayer, ShardDispatcher {}
+contract ShardGateway is Relayer, ShardDispatcher {
+    constructor() Relayer(msg.sender) {}
+}

--- a/products/bridge/smart-contracts/foundry/test/periphery/TokenBridge.integration.t.sol
+++ b/products/bridge/smart-contracts/foundry/test/periphery/TokenBridge.integration.t.sol
@@ -41,12 +41,14 @@ contract TokenBridgeTests is Tester, IRelayerEvents {
         sourceValidatorManager = new ValidatorManager(validator);
         vm.prank(validator);
         sourceValidatorManager.initialize(validators);
+        vm.prank(validator);
         sourceChainGateway = new ChainGateway(address(sourceValidatorManager));
 
         // Deploy Target Infra
         remoteValidatorManager = new ValidatorManager(validator);
         vm.prank(validator);
         remoteValidatorManager.initialize(validators);
+        vm.prank(validator);
         remoteChainGateway = new ChainGateway(address(remoteValidatorManager));
 
         // Deploy LockAndReleaseTokenManagerUpgradeable
@@ -76,6 +78,12 @@ contract TokenBridgeTests is Tester, IRelayerEvents {
             )
         );
         remoteTokenManager = MintAndBurnTokenManagerUpgradeable(proxy);
+
+        // Register contracts to chaingateway
+        vm.prank(validator);
+        sourceChainGateway.register(address(sourceTokenManager));
+        vm.prank(validator);
+        remoteChainGateway.register(address(remoteTokenManager));
 
         // Deploy original ERC20
         originalToken = new TestToken(originalTokenSupply);


### PR DESCRIPTION
New `Registry` contract allows the owner to add and remove addresses from the a set of whitelist contracts in the registry. This is used by inheriting the abstract contract `Registry` and implementing the necessary functions to manage the registry. The implementation is done in the `Relayer` contract which is inherited into `ChainGateway`