### PR TITLE
ZIL-5548: Bridge: extend BridgeToken to be eventually compatible with ZilBridge

### DIFF
--- a/products/bridge/smart-contracts/contracts/periphery/BridgedToken.sol
+++ b/products/bridge/smart-contracts/contracts/periphery/BridgedToken.sol
@@ -20,7 +20,11 @@ contract BridgedToken is IERC20, ERC20, ERC20Burnable, Ownable {
 
     error LockProxyTransferToSelf();
 
-    function mintIfLockProxy(address from, address to, uint amount) internal {
+    function mintIfLockProxy(
+        address from,
+        address to,
+        uint256 amount
+    ) internal {
         if (from == lockProxyAddress) {
             if (to == lockProxyAddress) {
                 revert LockProxyTransferToSelf();

--- a/products/bridge/smart-contracts/contracts/periphery/BridgedToken.sol
+++ b/products/bridge/smart-contracts/contracts/periphery/BridgedToken.sol
@@ -36,8 +36,27 @@ contract BridgedToken is ERC20, ERC20Burnable, Ownable {
         _decimals = decimals_;
     }
 
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function circulatingSupply() external view returns (uint256 amount) {
+        return totalSupply() - balanceOf(lockProxyAddress);
+    }
+
     function mint(address to, uint256 amount) external onlyOwner {
         _mint(to, amount);
+    }
+
+    function burn(uint256 value) public override onlyOwner {
+        super.burn(value);
+    }
+
+    function burnFrom(
+        address account,
+        uint256 value
+    ) public override onlyOwner {
+        super.burnFrom(account, value);
     }
 
     function setLockProxyAddress(address lockProxyAddress_) external onlyOwner {
@@ -59,13 +78,5 @@ contract BridgedToken is ERC20, ERC20Burnable, Ownable {
     ) public override returns (bool) {
         mintIfLockProxy(from, to, value);
         return super.transferFrom(from, to, value);
-    }
-
-    function decimals() public view override returns (uint8) {
-        return _decimals;
-    }
-
-    function circulatingSupply() external view returns (uint256 amount) {
-        return totalSupply() - balanceOf(lockProxyAddress);
     }
 }

--- a/products/bridge/smart-contracts/contracts/periphery/BridgedToken.sol
+++ b/products/bridge/smart-contracts/contracts/periphery/BridgedToken.sol
@@ -1,20 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-interface IBridgedToken is IERC20 {
-    function mint(address to, uint256 amount) external;
-
-    function burn(uint256 value) external;
-
-    function burnFrom(address account, uint256 value) external;
-}
-
-contract BridgedToken is IERC20, ERC20, ERC20Burnable, Ownable {
+contract BridgedToken is ERC20, ERC20Burnable, Ownable {
     uint8 private immutable _decimals;
     address public lockProxyAddress;
 
@@ -41,7 +32,7 @@ contract BridgedToken is IERC20, ERC20, ERC20Burnable, Ownable {
         string memory name_,
         string memory symbol_,
         uint8 decimals_
-    ) ERC20(name_, symbol_) Ownable(msg.sender) {
+    ) ERC20(name_, symbol_) Ownable(_msgSender()) {
         _decimals = decimals_;
     }
 
@@ -56,8 +47,8 @@ contract BridgedToken is IERC20, ERC20, ERC20Burnable, Ownable {
     function transfer(
         address to,
         uint256 value
-    ) public override(ERC20, IERC20) returns (bool) {
-        mintIfLockProxy(msg.sender, to, value);
+    ) public override returns (bool) {
+        mintIfLockProxy(_msgSender(), to, value);
         return super.transfer(to, value);
     }
 
@@ -65,8 +56,8 @@ contract BridgedToken is IERC20, ERC20, ERC20Burnable, Ownable {
         address from,
         address to,
         uint256 value
-    ) public override(ERC20, IERC20) returns (bool) {
-        mintIfLockProxy(msg.sender, to, value);
+    ) public override returns (bool) {
+        mintIfLockProxy(from, to, value);
         return super.transferFrom(from, to, value);
     }
 

--- a/products/bridge/smart-contracts/foundry/test/periphery/BridgedToken.t.sol
+++ b/products/bridge/smart-contracts/foundry/test/periphery/BridgedToken.t.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.20;
+
+import {Tester} from "foundry/test/Tester.sol";
+import {BridgedToken} from "contracts/periphery/BridgedToken.sol";
+import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+interface ERC20Events {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+}
+
+contract BridgedTokenTests is Tester, ERC20Events {
+    address bridge = vm.createWallet("bridge").addr;
+    address zilBridge = vm.createWallet("zilBridge").addr;
+    address user = vm.createWallet("user").addr;
+    uint mintedAmount = 10 ether;
+
+    BridgedToken bridgedToken;
+
+    function setUp() external {
+        vm.prank(bridge);
+        bridgedToken = new BridgedToken("Gold", "GLD", 18);
+    }
+
+    function mint(address target) internal {
+        vm.prank(bridge);
+        bridgedToken.mint(target, mintedAmount);
+    }
+
+    function migrateToZilBridge(address owner) internal {
+        vm.startPrank(owner);
+        bridgedToken.setLockProxyAddress(zilBridge);
+        bridgedToken.renounceOwnership();
+        vm.stopPrank();
+    }
+
+    function test_migrateOwnershipToZilBridge() external {
+        migrateToZilBridge(bridge);
+
+        assertEq(bridgedToken.lockProxyAddress(), zilBridge);
+        assertEq(bridgedToken.owner(), address(0));
+    }
+
+    function test_transfer_asZilBridge_mintWhenNoLockedTokens() external {
+        address target = vm.createWallet("target").addr;
+        uint bridgeAmount = 100 ether;
+        migrateToZilBridge(bridge);
+        assertEq(bridgedToken.balanceOf(zilBridge), 0);
+        assertEq(bridgedToken.balanceOf(target), 0);
+
+        // Mint event
+        vm.expectEmit(address(bridgedToken));
+        emit ERC20Events.Transfer(address(0), zilBridge, bridgeAmount);
+        // Transfer event
+        vm.expectEmit(address(bridgedToken));
+        emit ERC20Events.Transfer(zilBridge, target, bridgeAmount);
+        vm.prank(zilBridge);
+        bridgedToken.transfer(target, bridgeAmount);
+
+        assertEq(bridgedToken.balanceOf(zilBridge), 0);
+        assertEq(bridgedToken.balanceOf(target), bridgeAmount);
+        assertEq(bridgedToken.circulatingSupply(), bridgeAmount);
+        assertEq(bridgedToken.totalSupply(), bridgeAmount);
+    }
+
+    function test_transfer_asZilBridge_transferWithLockedTokens() external {
+        address target = vm.createWallet("target").addr;
+        mint(zilBridge);
+        migrateToZilBridge(bridge);
+        assertEq(bridgedToken.circulatingSupply(), 0);
+        assertEq(bridgedToken.totalSupply(), mintedAmount);
+        assertEq(bridgedToken.balanceOf(zilBridge), mintedAmount);
+        assertEq(bridgedToken.balanceOf(target), 0);
+
+        // Transfer event
+        vm.expectEmit(address(bridgedToken));
+        emit ERC20Events.Transfer(zilBridge, target, mintedAmount);
+        vm.prank(zilBridge);
+        bridgedToken.transfer(target, mintedAmount);
+
+        assertEq(bridgedToken.balanceOf(zilBridge), 0);
+        assertEq(bridgedToken.balanceOf(target), mintedAmount);
+        assertEq(bridgedToken.circulatingSupply(), mintedAmount);
+        assertEq(bridgedToken.totalSupply(), mintedAmount);
+    }
+
+    function test_transferFrom_asZilBridge_mintWhenNoLockedTokens() external {
+        address target = vm.createWallet("target").addr;
+        uint bridgeAmount = 100 ether;
+        migrateToZilBridge(bridge);
+        assertEq(bridgedToken.balanceOf(zilBridge), 0);
+        assertEq(bridgedToken.balanceOf(target), 0);
+
+        vm.prank(zilBridge);
+        bridgedToken.approve(target, bridgeAmount);
+
+        // Mint event
+        vm.expectEmit(address(bridgedToken));
+        emit ERC20Events.Transfer(address(0), zilBridge, bridgeAmount);
+        // Transfer event
+        vm.expectEmit(address(bridgedToken));
+        emit ERC20Events.Transfer(zilBridge, target, bridgeAmount);
+        vm.prank(target);
+        bridgedToken.transferFrom(zilBridge, target, bridgeAmount);
+
+        assertEq(bridgedToken.balanceOf(zilBridge), 0);
+        assertEq(bridgedToken.balanceOf(target), bridgeAmount);
+        assertEq(bridgedToken.circulatingSupply(), bridgeAmount);
+        assertEq(bridgedToken.totalSupply(), bridgeAmount);
+    }
+
+    function test_transferFrom_asZilBridge_transferWithLockedTokens() external {
+        address target = vm.createWallet("target").addr;
+        mint(zilBridge);
+        migrateToZilBridge(bridge);
+        assertEq(bridgedToken.circulatingSupply(), 0);
+        assertEq(bridgedToken.totalSupply(), mintedAmount);
+        assertEq(bridgedToken.balanceOf(zilBridge), mintedAmount);
+        assertEq(bridgedToken.balanceOf(target), 0);
+
+        vm.prank(zilBridge);
+        bridgedToken.approve(target, mintedAmount);
+
+        // Transfer event
+        vm.expectEmit(address(bridgedToken));
+        emit ERC20Events.Transfer(zilBridge, target, mintedAmount);
+        vm.prank(target);
+        bridgedToken.transferFrom(zilBridge, target, mintedAmount);
+
+        assertEq(bridgedToken.balanceOf(zilBridge), 0);
+        assertEq(bridgedToken.balanceOf(target), mintedAmount);
+        assertEq(bridgedToken.circulatingSupply(), mintedAmount);
+        assertEq(bridgedToken.totalSupply(), mintedAmount);
+    }
+
+    function test_transfer_revertUserWithoutTokens() external {
+        address target = vm.createWallet("target").addr;
+        uint amount = 20 ether;
+        migrateToZilBridge(bridge);
+
+        vm.prank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Errors.ERC20InsufficientBalance.selector,
+                user,
+                0,
+                amount
+            )
+        );
+        bridgedToken.transfer(target, amount);
+    }
+
+    function test_transferFrom_revertUserWithoutTokens() external TODO {
+        address target = vm.createWallet("target").addr;
+        uint amount = 20 ether;
+        migrateToZilBridge(bridge);
+
+        vm.prank(user);
+        bridgedToken.approve(target, amount);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Errors.ERC20InsufficientBalance.selector,
+                user,
+                0,
+                amount
+            )
+        );
+        bridgedToken.transferFrom(user, target, amount);
+    }
+
+    function test_transfer_UserWithTokens() external TODO {
+        mint(user);
+        migrateToZilBridge(bridge);
+    }
+
+    function test_transferFrom_UserWithTokens() external TODO {
+        mint(user);
+        migrateToZilBridge(bridge);
+    }
+
+    function test_mint_revertsAfterMigration() external TODO {
+        migrateToZilBridge(bridge);
+    }
+
+    function test_burn_revertsAfterMigration() external TODO {
+        migrateToZilBridge(bridge);
+    }
+}


### PR DESCRIPTION
This extended version of the contract is taken from: [SwitcheoTokenETH](https://github.com/Zilliqa/switcheo-tradehub-eth/blob/master/contracts/tokens/SwitcheoTokenETH.sol). It has also been refactored to support the newer version of solidity which is used by all other parts of the contract, including to new ways of error handling. 

The ZilBridge, uses the `transfer` capability to mint new tokens if it does not currently hold any. Essentially it is a `MintAndLock` bridge rather than our `MintAndBurn` bridge. With this capability with we could eventually migrate the token to zilbridge by assigning the corresponding `lockProxyAddress` with `setLockProxyAddress` and renounce ownership over the contract to disable the `mint` and `burn` external functions.

NB: once deployed the owner will be the `MintAndBurnTokenManager` which does not have the ability to call `setLockProxyAddress` or renouncing the ownership. These functionalities will be added later to the `MintAndBurnTokenManager` when it becomes necessary.