### PR TITLE
ZIL-5554: Bridge Update gas estimation for ZQ networks on validators

### DIFF
--- a/products/bridge/bridge-validators/config.toml
+++ b/products/bridge/bridge-validators/config.toml
@@ -7,15 +7,15 @@
 [[chain_configs]]
 chain_gateway_block_deployed = 36696045
 rpc_url = "https://bsc-prebsc-dataseed.bnbchain.org"
-validator_manager_address = "0x3bBa7E3B4b2058d3F3D017FBCC552939d62Eebb5"
-chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
+validator_manager_address = "0x43Eca260173De3cF0A2a68a5b3477C420f816F47"
+chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 
 # BSC Mainnet
 # [[chain_configs]]
 # chain_gateway_block_deployed = 0
-# rpc_url = "https://bsc-dataseed1.binance.org"
-# validator_manager_address = "0x63B6ebD476C84bFDd5DcaCB3f974794FC6C2e721"
-# chain_gateway_address = "0x15A3D695EafF8d302eaF0a2e6b7b54F6A440C570"
+# rpc_url = "https://binance.llamarpc.com"
+# validator_manager_address = "0x5EDE85Ee7B2b4aefA88505Aa3893c1628FCeB0CE"
+# chain_gateway_address = "0x2114e979b7CFDd8b358502e00f50Fd5f7787Fe63"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8545"
@@ -31,8 +31,8 @@ chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
 rpc_url = "https://dev-api.zilliqa.com"
-validator_manager_address = "0x16bF46CAa709C01053da0d454111E284Ea8291AD"
-chain_gateway_address = "0x9e7FF4479511B8C497860633f3E136Fa21C99f5A"
+validator_manager_address = "0x28E0D96C5B0Fd26654bd5b29ccDf77BE60D8bc1F"
+chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true
 
@@ -40,6 +40,7 @@ legacy_gas_estimation = true
 # [[chain_configs]]
 # chain_gateway_block_deployed = 0
 # rpc_url = "https://api.zilliqa.com"
-# validator_manager_address = "0x8B64A6e53fC3A642E72E9Ac6709AeBc12aAc20f4"
-# chain_gateway_address = "0x1690B1e78b98332EC5601A510640f451daf1323F"
+# validator_manager_address = "0xF391A1Ee7b3ccad9a9451D2B7460Ac646F899f23"
+# chain_gateway_address = "0xE76669e1cCc150194eB92581baE79Ef6fa0E248E"
 # block_instant_finality = true
+# legacy_gas_estimation = true

--- a/products/bridge/bridge-validators/infra/cd/base/config-leader.toml
+++ b/products/bridge/bridge-validators/infra/cd/base/config-leader.toml
@@ -2,15 +2,15 @@
 [[chain_configs]]
 chain_gateway_block_deployed = 36696045
 rpc_url = "https://bsc-prebsc-dataseed.bnbchain.org"
-validator_manager_address = "0x3bBa7E3B4b2058d3F3D017FBCC552939d62Eebb5"
-chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
+validator_manager_address = "0x43Eca260173De3cF0A2a68a5b3477C420f816F47"
+chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 
 # BSC Mainnet
 # [[chain_configs]]
-# chain_gateway_block_deployed = 35300538
-# rpc_url = "https://bsc-mainnet.core.chainstack.com/f46f3fe682039b2ed570255458dcd7d9"
-# validator_manager_address = "0x95ebe761b40042F23b717e1e00ECF6b871f24173"
-# chain_gateway_address = "0x3fa391E5a4c1b55D04A1b164fDC67ECEb312B93d"
+# chain_gateway_block_deployed = 0
+# rpc_url = "https://binance.llamarpc.com"
+# validator_manager_address = "0x5EDE85Ee7B2b4aefA88505Aa3893c1628FCeB0CE"
+# chain_gateway_address = "0x2114e979b7CFDd8b358502e00f50Fd5f7787Fe63"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8545"
@@ -25,8 +25,17 @@ chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
-rpc_url = "http://xbridge-testnet-l2api.testnet-ase1.zq1.dev/"
-validator_manager_address = "0x16bF46CAa709C01053da0d454111E284Ea8291AD"
-chain_gateway_address = "0x9e7FF4479511B8C497860633f3E136Fa21C99f5A"
+rpc_url = "https://dev-api.zilliqa.com"
+validator_manager_address = "0x28E0D96C5B0Fd26654bd5b29ccDf77BE60D8bc1F"
+chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true
+
+# Zilliqa Mainnet
+# [[chain_configs]]
+# chain_gateway_block_deployed = 0
+# rpc_url = "https://api.zilliqa.com"
+# validator_manager_address = "0xF391A1Ee7b3ccad9a9451D2B7460Ac646F899f23"
+# chain_gateway_address = "0xE76669e1cCc150194eB92581baE79Ef6fa0E248E"
+# block_instant_finality = true
+# legacy_gas_estimation = true

--- a/products/bridge/bridge-validators/infra/cd/base/config.toml
+++ b/products/bridge/bridge-validators/infra/cd/base/config.toml
@@ -2,19 +2,20 @@
 #   "12D3KooWESbrSPohuw87dQDbJCB8qeeNgJsFD3ahkea3cu41m7bG",
 #   "/ip4/172.16.8.135/tcp/3333",
 # ]
+
 # BSC Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 36696045
 rpc_url = "https://bsc-prebsc-dataseed.bnbchain.org"
-validator_manager_address = "0x3bBa7E3B4b2058d3F3D017FBCC552939d62Eebb5"
-chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
+validator_manager_address = "0x43Eca260173De3cF0A2a68a5b3477C420f816F47"
+chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 
 # BSC Mainnet
 # [[chain_configs]]
-# chain_gateway_block_deployed = 35300538
-# rpc_url = "https://bsc-mainnet.core.chainstack.com/f46f3fe682039b2ed570255458dcd7d9"
-# validator_manager_address = "0x95ebe761b40042F23b717e1e00ECF6b871f24173"
-# chain_gateway_address = "0x3fa391E5a4c1b55D04A1b164fDC67ECEb312B93d"
+# chain_gateway_block_deployed = 0
+# rpc_url = "https://binance.llamarpc.com"
+# validator_manager_address = "0x5EDE85Ee7B2b4aefA88505Aa3893c1628FCeB0CE"
+# chain_gateway_address = "0x2114e979b7CFDd8b358502e00f50Fd5f7787Fe63"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8545"
@@ -29,8 +30,17 @@ chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
-rpc_url = "http://xbridge-testnet-l2api.testnet-ase1.zq1.dev/"
-validator_manager_address = "0x16bF46CAa709C01053da0d454111E284Ea8291AD"
-chain_gateway_address = "0x9e7FF4479511B8C497860633f3E136Fa21C99f5A"
+rpc_url = "https://dev-api.zilliqa.com"
+validator_manager_address = "0x28E0D96C5B0Fd26654bd5b29ccDf77BE60D8bc1F"
+chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true
+
+# Zilliqa Mainnet
+# [[chain_configs]]
+# chain_gateway_block_deployed = 0
+# rpc_url = "https://api.zilliqa.com"
+# validator_manager_address = "0xF391A1Ee7b3ccad9a9451D2B7460Ac646F899f23"
+# chain_gateway_address = "0xE76669e1cCc150194eB92581baE79Ef6fa0E248E"
+# block_instant_finality = true
+# legacy_gas_estimation = true

--- a/products/bridge/bridge-validators/infra/config-leader.toml
+++ b/products/bridge/bridge-validators/infra/config-leader.toml
@@ -2,15 +2,15 @@
 [[chain_configs]]
 chain_gateway_block_deployed = 36696045
 rpc_url = "https://bsc-prebsc-dataseed.bnbchain.org"
-validator_manager_address = "0x3bBa7E3B4b2058d3F3D017FBCC552939d62Eebb5"
-chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
+validator_manager_address = "0x43Eca260173De3cF0A2a68a5b3477C420f816F47"
+chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 
 # BSC Mainnet
 # [[chain_configs]]
-# chain_gateway_block_deployed = 35300538
-# rpc_url = "https://bsc-mainnet.core.chainstack.com/f46f3fe682039b2ed570255458dcd7d9"
-# validator_manager_address = "0x95ebe761b40042F23b717e1e00ECF6b871f24173"
-# chain_gateway_address = "0x3fa391E5a4c1b55D04A1b164fDC67ECEb312B93d"
+# chain_gateway_block_deployed = 0
+# rpc_url = "https://binance.llamarpc.com"
+# validator_manager_address = "0x5EDE85Ee7B2b4aefA88505Aa3893c1628FCeB0CE"
+# chain_gateway_address = "0x2114e979b7CFDd8b358502e00f50Fd5f7787Fe63"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8545"
@@ -25,8 +25,17 @@ chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
-rpc_url = "http://xbridge-testnet-l2api.testnet-ase1.zq1.dev/"
-validator_manager_address = "0x16bF46CAa709C01053da0d454111E284Ea8291AD"
-chain_gateway_address = "0x9e7FF4479511B8C497860633f3E136Fa21C99f5A"
+rpc_url = "https://dev-api.zilliqa.com"
+validator_manager_address = "0x28E0D96C5B0Fd26654bd5b29ccDf77BE60D8bc1F"
+chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true
+
+# Zilliqa Mainnet
+# [[chain_configs]]
+# chain_gateway_block_deployed = 0
+# rpc_url = "https://api.zilliqa.com"
+# validator_manager_address = "0xF391A1Ee7b3ccad9a9451D2B7460Ac646F899f23"
+# chain_gateway_address = "0xE76669e1cCc150194eB92581baE79Ef6fa0E248E"
+# block_instant_finality = true
+# legacy_gas_estimation = true

--- a/products/bridge/bridge-validators/infra/config.toml
+++ b/products/bridge/bridge-validators/infra/config.toml
@@ -2,19 +2,20 @@
 #   "12D3KooWESbrSPohuw87dQDbJCB8qeeNgJsFD3ahkea3cu41m7bG",
 #   "/ip4/172.16.8.135/tcp/3333",
 # ]
+
 # BSC Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 36696045
 rpc_url = "https://bsc-prebsc-dataseed.bnbchain.org"
-validator_manager_address = "0x3bBa7E3B4b2058d3F3D017FBCC552939d62Eebb5"
-chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
+validator_manager_address = "0x43Eca260173De3cF0A2a68a5b3477C420f816F47"
+chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 
 # BSC Mainnet
 # [[chain_configs]]
-# chain_gateway_block_deployed = 35300538
-# rpc_url = "https://bsc-mainnet.core.chainstack.com/f46f3fe682039b2ed570255458dcd7d9"
-# validator_manager_address = "0x95ebe761b40042F23b717e1e00ECF6b871f24173"
-# chain_gateway_address = "0x3fa391E5a4c1b55D04A1b164fDC67ECEb312B93d"
+# chain_gateway_block_deployed = 0
+# rpc_url = "https://binance.llamarpc.com"
+# validator_manager_address = "0x5EDE85Ee7B2b4aefA88505Aa3893c1628FCeB0CE"
+# chain_gateway_address = "0x2114e979b7CFDd8b358502e00f50Fd5f7787Fe63"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8545"
@@ -29,8 +30,17 @@ chain_gateway_address = "0xCD6D04BB823cBBEd853B43DFe421Be47fc49AbC5"
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
-rpc_url = "http://xbridge-testnet-l2api.testnet-ase1.zq1.dev/"
-validator_manager_address = "0x16bF46CAa709C01053da0d454111E284Ea8291AD"
-chain_gateway_address = "0x9e7FF4479511B8C497860633f3E136Fa21C99f5A"
+rpc_url = "https://dev-api.zilliqa.com"
+validator_manager_address = "0x28E0D96C5B0Fd26654bd5b29ccDf77BE60D8bc1F"
+chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true
+
+# Zilliqa Mainnet
+# [[chain_configs]]
+# chain_gateway_block_deployed = 0
+# rpc_url = "https://api.zilliqa.com"
+# validator_manager_address = "0xF391A1Ee7b3ccad9a9451D2B7460Ac646F899f23"
+# chain_gateway_address = "0xE76669e1cCc150194eB92581baE79Ef6fa0E248E"
+# block_instant_finality = true
+# legacy_gas_estimation = true

--- a/products/bridge/bridge-validators/src/validator_node.rs
+++ b/products/bridge/bridge-validators/src/validator_node.rs
@@ -202,6 +202,7 @@ impl ValidatorNode {
                 function_call.clone().gas(gas_estimate * 130 / 100) // Apply multiplier
             } else {
                 let function_call = function_call.clone();
+                // `eth_call` does not seem to work on ZQ so it had to be skipped
                 if let Err(contract_err) = function_call.call().await {
                     match contract_err.decode_contract_revert::<ChainGatewayErrors>() {
                         Some(ChainGatewayErrors::AlreadyDispatched(_)) => {


### PR DESCRIPTION
Because gas estimations given by `eth_estimateGas` being too tight for transactions that call scilla interoperability precompiles. Thus I had to manually query gas estimate and also multiply it for buffer. 30% more was the option I chose, that is what is also adopted by foundry by default

Also updated the addresses of the bridge to match the new contracts