### PR TITLE
Add projectId for WalletConnect Cloud

### DIFF
--- a/products/bridge/bridge-web/src/config/wallet.ts
+++ b/products/bridge/bridge-web/src/config/wallet.ts
@@ -12,7 +12,8 @@ export const { chains, publicClient } = configureChains(
 const connectors = connectorsForWallets([
   {
     groupName: "Recommended",
-    wallets: [metaMaskWallet({ chains, projectId: "" })],
+    // Project ID for WalletConnect Cloud.
+    wallets: [metaMaskWallet({ chains, projectId: "f4d0c28ceef8b7064e5d92457c6f283b" })],
   },
 ]);
 


### PR DESCRIPTION
I figured it wasn't worth making this secret since it will be included in the frontend anyway, so is basically public.

Its easy to rotate later. We probably should because this project is tied to `james@zilliqa.com`, but it will do for now...