### PR TITLE
Add nonce manager

### DIFF
--- a/products/bridge/bridge-validators/src/client.rs
+++ b/products/bridge/bridge-validators/src/client.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{ChainGateway, ValidatorManager};
 use anyhow::Result;
 use ethers::{
-    middleware::{MiddlewareBuilder, SignerMiddleware},
+    middleware::{MiddlewareBuilder, NonceManagerMiddleware, SignerMiddleware},
     providers::{Http, Middleware, Provider},
     signers::{LocalWallet, Signer},
     types::{Address, U256},
@@ -11,7 +11,7 @@ use ethers::{
 
 use crate::ChainConfig;
 
-pub type Client = SignerMiddleware<Provider<Http>, LocalWallet>;
+pub type Client = SignerMiddleware<NonceManagerMiddleware<Provider<Http>>, LocalWallet>;
 
 #[derive(Debug, Clone)]
 pub struct ChainClient {
@@ -28,6 +28,7 @@ pub struct ChainClient {
 impl ChainClient {
     pub async fn new(config: &ChainConfig, wallet: LocalWallet) -> Result<Self> {
         let provider = Provider::<Http>::try_from(config.rpc_url.as_str())?;
+        let provider = provider.nonce_manager(wallet.address());
         // let provider = Provider::<Ws>::connect(&config.rpc_url).await?;
         let chain_id = provider.get_chainid().await?;
 


### PR DESCRIPTION
Txns on mainnet were failing when they were being done too close together, aka with the same nonce. Thus those transactions with the higher nonce are simply lost