### PR TITLE
Fix UI where event is emitted before listener

### DIFF
--- a/products/bridge/bridge-web/src/App.tsx
+++ b/products/bridge/bridge-web/src/App.tsx
@@ -284,6 +284,45 @@ function App() {
               });
             },
           });
+
+          // Double check if it has already been dispatched before event listener catches it
+          const blockNumber = await toChainClient.getBlockNumber();
+          const dispatched = await toChainClient.getLogs({
+            address: toChainConfig.chainGatewayAddress,
+            event: getAbiItem({
+              abi: chainGatewayAbi,
+              name: "Dispatched",
+            }),
+            args: {
+              nonce,
+            },
+            fromBlock: blockNumber - 50n,
+            toBlock: "latest",
+          });
+
+          if (dispatched.length > 0) {
+            toast.update(id, {
+              render: (
+                <div>
+                  Bridge txn complete, funds arrived to {toChainConfig.name}{" "}
+                  chain. View on{" "}
+                  <a
+                    className="link text-ellipsis w-10"
+                    onClick={() =>
+                      window.open(
+                        `${toChainConfig.blockExplorer}${dispatched[0].transactionHash}`,
+                        "_blank"
+                      )
+                    }
+                  >
+                    block explorer
+                  </a>
+                </div>
+              ),
+              type: "success",
+              isLoading: false,
+            });
+          }
         })();
 
         setAmount("");


### PR DESCRIPTION
Had to fix an issue where the event occurs before the the event listener is able to pick up when bridging from ZQ -> BSC.

Thus we verify if the event has occurred before the event listener begins