### PR TITLE
US-0: XBridge Validator - Fetch validator_manager_address on initialize

### DIFF
--- a/products/bridge/bridge-validators/config.local.toml
+++ b/products/bridge/bridge-validators/config.local.toml
@@ -2,14 +2,12 @@
 [[chain_configs]]
 chain_gateway_block_deployed = 0
 rpc_url = "https://bsc-prebsc-dataseed.bnbchain.org"
-validator_manager_address = "0x462777dC056b3835d486f5f1Dd806195A569487F"
 chain_gateway_address = "0x5cE584e24f6703f3197Ca83d442807cB82474f8D"
 
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 0
 rpc_url = "https://dev-api.zilliqa.com"
-validator_manager_address = "0xfb6FC691A94422419bF3538B3c2C7898E4Ab1424"
 chain_gateway_address = "0x18BCE81F9De993cdB2ebd680a44A8068B62D7f26"
 block_instant_finality = true
 legacy_gas_estimation = true

--- a/products/bridge/bridge-validators/config.toml
+++ b/products/bridge/bridge-validators/config.toml
@@ -7,31 +7,26 @@
 [[chain_configs]]
 chain_gateway_block_deployed = 36696045
 rpc_url = "https://bsc-prebsc-dataseed.bnbchain.org"
-validator_manager_address = "0x43Eca260173De3cF0A2a68a5b3477C420f816F47"
 chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 
 # BSC Mainnet
 # [[chain_configs]]
 # chain_gateway_block_deployed = 0
 # rpc_url = "https://binance.llamarpc.com"
-# validator_manager_address = "0x5EDE85Ee7B2b4aefA88505Aa3893c1628FCeB0CE"
 # chain_gateway_address = "0x2114e979b7CFDd8b358502e00f50Fd5f7787Fe63"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8545"
-# validator_manager_address = "0x4a50E1Be218279ca980EAb216d95E0A48B5aE872"
 # chain_gateway_address = "0x4212b368876a54F99c741C8B5b64be2e52a6956b"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8546"
-# validator_manager_address = "0x4a50E1Be218279ca980EAb216d95E0A48B5aE8https://bsc.blockpi.network/v1/rpc/public72"
 # chain_gateway_address = "0x4212b368876a54F99c741C8B5b64be2e52a6956b"
 
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
 rpc_url = "https://dev-api.zilliqa.com"
-validator_manager_address = "0x28E0D96C5B0Fd26654bd5b29ccDf77BE60D8bc1F"
 chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true
@@ -40,7 +35,6 @@ legacy_gas_estimation = true
 # [[chain_configs]]
 # chain_gateway_block_deployed = 0
 # rpc_url = "https://api.zilliqa.com"
-# validator_manager_address = "0xF391A1Ee7b3ccad9a9451D2B7460Ac646F899f23"
 # chain_gateway_address = "0xE76669e1cCc150194eB92581baE79Ef6fa0E248E"
 # block_instant_finality = true
 # legacy_gas_estimation = true

--- a/products/bridge/bridge-validators/infra/config-leader.toml
+++ b/products/bridge/bridge-validators/infra/config-leader.toml
@@ -2,31 +2,26 @@
 [[chain_configs]]
 chain_gateway_block_deployed = 36696045
 rpc_url = "https://bsc-prebsc-dataseed.bnbchain.org"
-validator_manager_address = "0x43Eca260173De3cF0A2a68a5b3477C420f816F47"
 chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 
 # BSC Mainnet
 # [[chain_configs]]
 # chain_gateway_block_deployed = 0
 # rpc_url = "https://binance.llamarpc.com"
-# validator_manager_address = "0x5EDE85Ee7B2b4aefA88505Aa3893c1628FCeB0CE"
 # chain_gateway_address = "0x2114e979b7CFDd8b358502e00f50Fd5f7787Fe63"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8545"
-# validator_manager_address = "0x4a50E1Be218279ca980EAb216d95E0A48B5aE872"
 # chain_gateway_address = "0x4212b368876a54F99c741C8B5b64be2e52a6956b"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8546"
-# validator_manager_address = "0x4a50E1Be218279ca980EAb216d95E0A48B5aE8https://bsc.blockpi.network/v1/rpc/public72"
 # chain_gateway_address = "0x4212b368876a54F99c741C8B5b64be2e52a6956b"
 
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
 rpc_url = "https://dev-api.zilliqa.com"
-validator_manager_address = "0x28E0D96C5B0Fd26654bd5b29ccDf77BE60D8bc1F"
 chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true
@@ -35,7 +30,6 @@ legacy_gas_estimation = true
 # [[chain_configs]]
 # chain_gateway_block_deployed = 0
 # rpc_url = "https://api.zilliqa.com"
-# validator_manager_address = "0xF391A1Ee7b3ccad9a9451D2B7460Ac646F899f23"
 # chain_gateway_address = "0xE76669e1cCc150194eB92581baE79Ef6fa0E248E"
 # block_instant_finality = true
 # legacy_gas_estimation = true

--- a/products/bridge/bridge-validators/infra/config.toml
+++ b/products/bridge/bridge-validators/infra/config.toml
@@ -7,31 +7,26 @@
 [[chain_configs]]
 chain_gateway_block_deployed = 36696045
 rpc_url = "https://bsc-prebsc-dataseed.bnbchain.org"
-validator_manager_address = "0x43Eca260173De3cF0A2a68a5b3477C420f816F47"
 chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 
 # BSC Mainnet
 # [[chain_configs]]
 # chain_gateway_block_deployed = 0
 # rpc_url = "https://binance.llamarpc.com"
-# validator_manager_address = "0x5EDE85Ee7B2b4aefA88505Aa3893c1628FCeB0CE"
 # chain_gateway_address = "0x2114e979b7CFDd8b358502e00f50Fd5f7787Fe63"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8545"
-# validator_manager_address = "0x4a50E1Be218279ca980EAb216d95E0A48B5aE872"
 # chain_gateway_address = "0x4212b368876a54F99c741C8B5b64be2e52a6956b"
 
 # [[chain_configs]]
 # rpc_url = "http://localhost:8546"
-# validator_manager_address = "0x4a50E1Be218279ca980EAb216d95E0A48B5aE8https://bsc.blockpi.network/v1/rpc/public72"
 # chain_gateway_address = "0x4212b368876a54F99c741C8B5b64be2e52a6956b"
 
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
 rpc_url = "https://dev-api.zilliqa.com"
-validator_manager_address = "0x28E0D96C5B0Fd26654bd5b29ccDf77BE60D8bc1F"
 chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true
@@ -40,7 +35,6 @@ legacy_gas_estimation = true
 # [[chain_configs]]
 # chain_gateway_block_deployed = 0
 # rpc_url = "https://api.zilliqa.com"
-# validator_manager_address = "0xF391A1Ee7b3ccad9a9451D2B7460Ac646F899f23"
 # chain_gateway_address = "0xE76669e1cCc150194eB92581baE79Ef6fa0E248E"
 # block_instant_finality = true
 # legacy_gas_estimation = true

--- a/products/bridge/bridge-validators/src/block.rs
+++ b/products/bridge/bridge-validators/src/block.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, time::Duration};
 use async_stream::try_stream;
 use async_trait::async_trait;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use ethers::{
     providers::Middleware,
     types::{BlockNumber, Filter, Log, U64},

--- a/products/bridge/bridge-validators/src/client.rs
+++ b/products/bridge/bridge-validators/src/client.rs
@@ -37,9 +37,13 @@ impl ChainClient {
                 .nonce_manager(wallet.address()),
         );
 
+        // TODO: get the validator_manager_address from chain_gateway itself
+        let chain_gateway = ChainGateway::new(config.chain_gateway_address, client.clone());
+        let validator_manager_address: Address = chain_gateway.validator_manager().call().await?;
+
         Ok(ChainClient {
             client,
-            validator_manager_address: config.validator_manager_address,
+            validator_manager_address,
             chain_gateway_address: config.chain_gateway_address,
             chain_id,
             wallet,

--- a/products/bridge/bridge-validators/src/main.rs
+++ b/products/bridge/bridge-validators/src/main.rs
@@ -28,7 +28,6 @@ abigen!(ValidatorManager, "abi/ValidatorManager.json");
 #[serde(deny_unknown_fields)]
 pub struct ChainConfig {
     pub rpc_url: String,
-    pub validator_manager_address: Address,
     pub chain_gateway_address: Address,
     pub chain_gateway_block_deployed: u64,
     pub block_instant_finality: Option<bool>,


### PR DESCRIPTION
Make the validator fetch the validator_manager addresses when it boots up instead of hardcoding it. It is always stored in the chain_gateway anyways.