### PR TITLE
US-0: XBridge FE/BE update abis and addresses for new contracts

### DIFF
--- a/products/bridge/bridge-validators/abi/ChainGateway.json
+++ b/products/bridge/bridge-validators/abi/ChainGateway.json
@@ -1,24 +1,24 @@
 [
+  { "type": "constructor", "inputs": [], "stateMutability": "nonpayable" },
   {
-    "type": "constructor",
-    "inputs": [
-      {
-        "name": "_validatorManager",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "dispatch",
     "inputs": [
-      {
-        "name": "sourceChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
+      { "name": "sourceChainId", "type": "uint256", "internalType": "uint256" },
       { "name": "target", "type": "address", "internalType": "address" },
       { "name": "call", "type": "bytes", "internalType": "bytes" },
       { "name": "gasLimit", "type": "uint256", "internalType": "uint256" },
@@ -32,16 +32,32 @@
     "type": "function",
     "name": "dispatched",
     "inputs": [
-      { "name": "", "type": "uint256", "internalType": "uint256" },
-      { "name": "", "type": "uint256", "internalType": "uint256" }
+      { "name": "sourceChainId", "type": "uint256", "internalType": "uint256" },
+      { "name": "nonce", "type": "uint256", "internalType": "uint256" }
     ],
     "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "_validatorManager",
+        "type": "address",
+        "internalType": "address"
+      },
+      { "name": "_owner", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "nonce",
-    "inputs": [],
+    "inputs": [
+      { "name": "chainId", "type": "uint256", "internalType": "uint256" }
+    ],
     "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
     "stateMutability": "view"
   },
@@ -50,6 +66,20 @@
     "name": "owner",
     "inputs": [],
     "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "view"
   },
   {
@@ -64,7 +94,9 @@
   {
     "type": "function",
     "name": "registered",
-    "inputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "inputs": [
+      { "name": "target", "type": "address", "internalType": "address" }
+    ],
     "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
     "stateMutability": "view"
   },
@@ -72,11 +104,7 @@
     "type": "function",
     "name": "relay",
     "inputs": [
-      {
-        "name": "targetChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
+      { "name": "targetChainId", "type": "uint256", "internalType": "uint256" },
       { "name": "target", "type": "address", "internalType": "address" },
       { "name": "call", "type": "bytes", "internalType": "bytes" },
       { "name": "gasLimit", "type": "uint256", "internalType": "uint256" }
@@ -88,11 +116,7 @@
     "type": "function",
     "name": "relayWithMetadata",
     "inputs": [
-      {
-        "name": "targetChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
+      { "name": "targetChainId", "type": "uint256", "internalType": "uint256" },
       { "name": "target", "type": "address", "internalType": "address" },
       { "name": "callSelector", "type": "bytes4", "internalType": "bytes4" },
       { "name": "callData", "type": "bytes", "internalType": "bytes" },
@@ -105,6 +129,19 @@
     "type": "function",
     "name": "renounceOwnership",
     "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setValidatorManager",
+    "inputs": [
+      {
+        "name": "_validatorManager",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "outputs": [],
     "stateMutability": "nonpayable"
   },
@@ -128,16 +165,50 @@
   },
   {
     "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      { "name": "data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
     "name": "validatorManager",
     "inputs": [],
-    "outputs": [
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "ContractRegistered",
+    "inputs": [
       {
-        "name": "",
+        "name": "target",
         "type": "address",
-        "internalType": "contract ValidatorManager"
+        "indexed": false,
+        "internalType": "address"
       }
     ],
-    "stateMutability": "view"
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ContractUnregistered",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
   },
   {
     "type": "event",
@@ -172,6 +243,38 @@
         "type": "uint256",
         "indexed": true,
         "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
       }
     ],
     "anonymous": false
@@ -232,20 +335,52 @@
     ],
     "anonymous": false
   },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      { "name": "target", "type": "address", "internalType": "address" }
+    ]
+  },
   { "type": "error", "name": "AlreadyDispatched", "inputs": [] },
-  { "type": "error", "name": "NonContractCaller", "inputs": [] },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      { "name": "implementation", "type": "address", "internalType": "address" }
+    ]
+  },
+  { "type": "error", "name": "ERC1967NonPayable", "inputs": [] },
+  { "type": "error", "name": "FailedInnerCall", "inputs": [] },
+  { "type": "error", "name": "InvalidInitialization", "inputs": [] },
+  {
+    "type": "error",
+    "name": "NonContractCaller",
+    "inputs": [
+      { "name": "target", "type": "address", "internalType": "address" }
+    ]
+  },
+  { "type": "error", "name": "NotInitializing", "inputs": [] },
   {
     "type": "error",
     "name": "NotRegistered",
     "inputs": [
-      {
-        "name": "targetAddress",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "targetAddress", "type": "address", "internalType": "address" }
     ]
   },
-  { "type": "error", "name": "NotValidator", "inputs": [] },
   {
     "type": "error",
     "name": "OwnableInvalidOwner",
@@ -259,5 +394,11 @@
     "inputs": [
       { "name": "account", "type": "address", "internalType": "address" }
     ]
+  },
+  { "type": "error", "name": "UUPSUnauthorizedCallContext", "inputs": [] },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [{ "name": "slot", "type": "bytes32", "internalType": "bytes32" }]
   }
 ]

--- a/products/bridge/bridge-validators/abi/ValidatorManager.json
+++ b/products/bridge/bridge-validators/abi/ValidatorManager.json
@@ -1,9 +1,17 @@
 [
+  { "type": "constructor", "inputs": [], "stateMutability": "nonpayable" },
   {
-    "type": "constructor",
-    "inputs": [
-      { "name": "_owner", "type": "address", "internalType": "address" }
-    ],
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
     "stateMutability": "nonpayable"
   },
   {
@@ -28,11 +36,8 @@
     "type": "function",
     "name": "initialize",
     "inputs": [
-      {
-        "name": "validators",
-        "type": "address[]",
-        "internalType": "address[]"
-      }
+      { "name": "_owner", "type": "address", "internalType": "address" },
+      { "name": "validators", "type": "address[]", "internalType": "address[]" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -51,6 +56,20 @@
     "name": "owner",
     "inputs": [],
     "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "view"
   },
   {
@@ -80,6 +99,20 @@
   },
   {
     "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      { "name": "data", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
     "name": "validateMessageWithSupermajority",
     "inputs": [
       {
@@ -101,6 +134,38 @@
   },
   {
     "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "OwnershipTransferred",
     "inputs": [
       {
@@ -118,6 +183,26 @@
     ],
     "anonymous": false
   },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      { "name": "target", "type": "address", "internalType": "address" }
+    ]
+  },
   { "type": "error", "name": "ECDSAInvalidSignature", "inputs": [] },
   {
     "type": "error",
@@ -131,9 +216,20 @@
     "name": "ECDSAInvalidSignatureS",
     "inputs": [{ "name": "s", "type": "bytes32", "internalType": "bytes32" }]
   },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      { "name": "implementation", "type": "address", "internalType": "address" }
+    ]
+  },
+  { "type": "error", "name": "ERC1967NonPayable", "inputs": [] },
+  { "type": "error", "name": "FailedInnerCall", "inputs": [] },
+  { "type": "error", "name": "InvalidInitialization", "inputs": [] },
   { "type": "error", "name": "InvalidValidatorOrSignatures", "inputs": [] },
   { "type": "error", "name": "NoSupermajority", "inputs": [] },
   { "type": "error", "name": "NonUniqueOrUnorderedSignatures", "inputs": [] },
+  { "type": "error", "name": "NotInitializing", "inputs": [] },
   {
     "type": "error",
     "name": "OwnableInvalidOwner",
@@ -147,5 +243,11 @@
     "inputs": [
       { "name": "account", "type": "address", "internalType": "address" }
     ]
+  },
+  { "type": "error", "name": "UUPSUnauthorizedCallContext", "inputs": [] },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [{ "name": "slot", "type": "bytes32", "internalType": "bytes32" }]
   }
 ]

--- a/products/bridge/bridge-web/src/abi/ChainGateway.ts
+++ b/products/bridge/bridge-web/src/abi/ChainGateway.ts
@@ -1,25 +1,24 @@
 export const chainGatewayAbi = [
+  { type: "constructor", inputs: [], stateMutability: "nonpayable" },
   {
-    type: "constructor",
-    inputs: [
-      {
-        name: "_validatorManager",
-        type: "address",
-        internalType: "address",
-      },
-      { name: "_owner", type: "address", internalType: "address" },
-    ],
+    type: "function",
+    name: "UPGRADE_INTERFACE_VERSION",
+    inputs: [],
+    outputs: [{ name: "", type: "string", internalType: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "acceptOwnership",
+    inputs: [],
+    outputs: [],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "dispatch",
     inputs: [
-      {
-        name: "sourceChainId",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "sourceChainId", type: "uint256", internalType: "uint256" },
       { name: "target", type: "address", internalType: "address" },
       { name: "call", type: "bytes", internalType: "bytes" },
       { name: "gasLimit", type: "uint256", internalType: "uint256" },
@@ -33,16 +32,26 @@ export const chainGatewayAbi = [
     type: "function",
     name: "dispatched",
     inputs: [
-      { name: "", type: "uint256", internalType: "uint256" },
-      { name: "", type: "uint256", internalType: "uint256" },
+      { name: "sourceChainId", type: "uint256", internalType: "uint256" },
+      { name: "nonce", type: "uint256", internalType: "uint256" },
     ],
     outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
+    name: "initialize",
+    inputs: [
+      { name: "_validatorManager", type: "address", internalType: "address" },
+      { name: "_owner", type: "address", internalType: "address" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
     name: "nonce",
-    inputs: [],
+    inputs: [{ name: "chainId", type: "uint256", internalType: "uint256" }],
     outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
     stateMutability: "view",
   },
@@ -55,6 +64,20 @@ export const chainGatewayAbi = [
   },
   {
     type: "function",
+    name: "pendingOwner",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "proxiableUUID",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "register",
     inputs: [{ name: "newTarget", type: "address", internalType: "address" }],
     outputs: [],
@@ -63,7 +86,7 @@ export const chainGatewayAbi = [
   {
     type: "function",
     name: "registered",
-    inputs: [{ name: "", type: "address", internalType: "address" }],
+    inputs: [{ name: "target", type: "address", internalType: "address" }],
     outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
@@ -71,11 +94,7 @@ export const chainGatewayAbi = [
     type: "function",
     name: "relay",
     inputs: [
-      {
-        name: "targetChainId",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "targetChainId", type: "uint256", internalType: "uint256" },
       { name: "target", type: "address", internalType: "address" },
       { name: "call", type: "bytes", internalType: "bytes" },
       { name: "gasLimit", type: "uint256", internalType: "uint256" },
@@ -87,11 +106,7 @@ export const chainGatewayAbi = [
     type: "function",
     name: "relayWithMetadata",
     inputs: [
-      {
-        name: "targetChainId",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "targetChainId", type: "uint256", internalType: "uint256" },
       { name: "target", type: "address", internalType: "address" },
       { name: "callSelector", type: "bytes4", internalType: "bytes4" },
       { name: "callData", type: "bytes", internalType: "bytes" },
@@ -104,6 +119,15 @@ export const chainGatewayAbi = [
     type: "function",
     name: "renounceOwnership",
     inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "setValidatorManager",
+    inputs: [
+      { name: "_validatorManager", type: "address", internalType: "address" },
+    ],
     outputs: [],
     stateMutability: "nonpayable",
   },
@@ -125,16 +149,46 @@ export const chainGatewayAbi = [
   },
   {
     type: "function",
+    name: "upgradeToAndCall",
+    inputs: [
+      { name: "newImplementation", type: "address", internalType: "address" },
+      { name: "data", type: "bytes", internalType: "bytes" },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
     name: "validatorManager",
     inputs: [],
-    outputs: [
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "event",
+    name: "ContractRegistered",
+    inputs: [
       {
-        name: "",
+        name: "target",
         type: "address",
-        internalType: "contract ValidatorManager",
+        indexed: false,
+        internalType: "address",
       },
     ],
-    stateMutability: "view",
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ContractUnregistered",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
   },
   {
     type: "event",
@@ -152,12 +206,7 @@ export const chainGatewayAbi = [
         indexed: true,
         internalType: "address",
       },
-      {
-        name: "success",
-        type: "bool",
-        indexed: false,
-        internalType: "bool",
-      },
+      { name: "success", type: "bool", indexed: false, internalType: "bool" },
       {
         name: "response",
         type: "bytes",
@@ -169,6 +218,38 @@ export const chainGatewayAbi = [
         type: "uint256",
         indexed: true,
         internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Initialized",
+    inputs: [
+      {
+        name: "version",
+        type: "uint64",
+        indexed: false,
+        internalType: "uint64",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferStarted",
+    inputs: [
+      {
+        name: "previousOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
       },
     ],
     anonymous: false,
@@ -208,12 +289,7 @@ export const chainGatewayAbi = [
         indexed: false,
         internalType: "address",
       },
-      {
-        name: "call",
-        type: "bytes",
-        indexed: false,
-        internalType: "bytes",
-      },
+      { name: "call", type: "bytes", indexed: false, internalType: "bytes" },
       {
         name: "gasLimit",
         type: "uint256",
@@ -229,20 +305,48 @@ export const chainGatewayAbi = [
     ],
     anonymous: false,
   },
+  {
+    type: "event",
+    name: "Upgraded",
+    inputs: [
+      {
+        name: "implementation",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "AddressEmptyCode",
+    inputs: [{ name: "target", type: "address", internalType: "address" }],
+  },
   { type: "error", name: "AlreadyDispatched", inputs: [] },
-  { type: "error", name: "NonContractCaller", inputs: [] },
+  {
+    type: "error",
+    name: "ERC1967InvalidImplementation",
+    inputs: [
+      { name: "implementation", type: "address", internalType: "address" },
+    ],
+  },
+  { type: "error", name: "ERC1967NonPayable", inputs: [] },
+  { type: "error", name: "FailedInnerCall", inputs: [] },
+  { type: "error", name: "InvalidInitialization", inputs: [] },
+  {
+    type: "error",
+    name: "NonContractCaller",
+    inputs: [{ name: "target", type: "address", internalType: "address" }],
+  },
+  { type: "error", name: "NotInitializing", inputs: [] },
   {
     type: "error",
     name: "NotRegistered",
     inputs: [
-      {
-        name: "targetAddress",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "targetAddress", type: "address", internalType: "address" },
     ],
   },
-  { type: "error", name: "NotValidator", inputs: [] },
   {
     type: "error",
     name: "OwnableInvalidOwner",
@@ -252,5 +356,11 @@ export const chainGatewayAbi = [
     type: "error",
     name: "OwnableUnauthorizedAccount",
     inputs: [{ name: "account", type: "address", internalType: "address" }],
+  },
+  { type: "error", name: "UUPSUnauthorizedCallContext", inputs: [] },
+  {
+    type: "error",
+    name: "UUPSUnsupportedProxiableUUID",
+    inputs: [{ name: "slot", type: "bytes32", internalType: "bytes32" }],
   },
 ] as const;

--- a/products/bridge/bridge-web/src/abi/TokenManager.ts
+++ b/products/bridge/bridge-web/src/abi/TokenManager.ts
@@ -15,16 +15,19 @@ export const tokenManagerAbi = [
         type: "tuple",
         internalType: "struct CallMetadata",
         components: [
-          {
-            name: "sourceChainId",
-            type: "uint256",
-            internalType: "uint256",
-          },
+          { name: "sourceChainId", type: "uint256", internalType: "uint256" },
           { name: "sender", type: "address", internalType: "address" },
         ],
       },
       { name: "_args", type: "bytes", internalType: "bytes" },
     ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "acceptOwnership",
+    inputs: [],
     outputs: [],
     stateMutability: "nonpayable",
   },
@@ -47,11 +50,7 @@ export const tokenManagerAbi = [
     name: "getRemoteTokens",
     inputs: [
       { name: "token", type: "address", internalType: "address" },
-      {
-        name: "remoteChainId",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "remoteChainId", type: "uint256", internalType: "uint256" },
     ],
     outputs: [
       {
@@ -60,11 +59,7 @@ export const tokenManagerAbi = [
         internalType: "struct ITokenManagerStructs.RemoteToken",
         components: [
           { name: "token", type: "address", internalType: "address" },
-          {
-            name: "tokenManager",
-            type: "address",
-            internalType: "address",
-          },
+          { name: "tokenManager", type: "address", internalType: "address" },
           { name: "chainId", type: "uint256", internalType: "uint256" },
         ],
       },
@@ -94,6 +89,13 @@ export const tokenManagerAbi = [
   },
   {
     type: "function",
+    name: "pendingOwner",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "proxiableUUID",
     inputs: [],
     outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
@@ -110,11 +112,7 @@ export const tokenManagerAbi = [
         internalType: "struct ITokenManagerStructs.RemoteToken",
         components: [
           { name: "token", type: "address", internalType: "address" },
-          {
-            name: "tokenManager",
-            type: "address",
-            internalType: "address",
-          },
+          { name: "tokenManager", type: "address", internalType: "address" },
           { name: "chainId", type: "uint256", internalType: "uint256" },
         ],
       },
@@ -148,16 +146,8 @@ export const tokenManagerAbi = [
     name: "transfer",
     inputs: [
       { name: "token", type: "address", internalType: "address" },
-      {
-        name: "remoteChainId",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "remoteRecipient",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "remoteChainId", type: "uint256", internalType: "uint256" },
+      { name: "remoteRecipient", type: "address", internalType: "address" },
       { name: "amount", type: "uint256", internalType: "uint256" },
     ],
     outputs: [],
@@ -181,11 +171,7 @@ export const tokenManagerAbi = [
     type: "function",
     name: "upgradeToAndCall",
     inputs: [
-      {
-        name: "newImplementation",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "newImplementation", type: "address", internalType: "address" },
       { name: "data", type: "bytes", internalType: "bytes" },
     ],
     outputs: [],
@@ -239,6 +225,25 @@ export const tokenManagerAbi = [
         type: "uint64",
         indexed: false,
         internalType: "uint64",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferStarted",
+    inputs: [
+      {
+        name: "previousOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
       },
     ],
     anonymous: false,
@@ -360,11 +365,7 @@ export const tokenManagerAbi = [
     type: "error",
     name: "ERC1967InvalidImplementation",
     inputs: [
-      {
-        name: "implementation",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "implementation", type: "address", internalType: "address" },
     ],
   },
   { type: "error", name: "ERC1967NonPayable", inputs: [] },

--- a/products/bridge/bridge-web/src/config/config.ts
+++ b/products/bridge/bridge-web/src/config/config.ts
@@ -61,7 +61,7 @@ export const chainConfigs: Partial<Record<Chains, ChainConfig>> =
           name: "Zilliqa Testnet",
           tokenManagerAddress: "0x1509988c41f02014aA59d455c6a0D67b5b50f129",
           tokenManagerType: TokenManagerType.LockAndRelease,
-          chainGatewayAddress: "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6",
+          chainGatewayAddress: "0x7370e69565BB2313C4dA12F9062C282513919230",
           wagmiChain: zilliqaTestnet,
           tokens: [
             {
@@ -82,7 +82,7 @@ export const chainConfigs: Partial<Record<Chains, ChainConfig>> =
           wagmiChain: bscTestnet,
           tokenManagerAddress: "0xA6D73210AF20a59832F264fbD991D2abf28401d0",
           tokenManagerType: TokenManagerType.MintAndBurn,
-          chainGatewayAddress: "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a",
+          chainGatewayAddress: "0xa9A14C90e53EdCD89dFd201A3bF94D867f8098fE",
           tokens: [
             {
               name: "TST",

--- a/products/bridge/bridge-web/src/config/config.ts
+++ b/products/bridge/bridge-web/src/config/config.ts
@@ -16,7 +16,7 @@ export const chainConfigs: Partial<Record<Chains, ChainConfig>> =
           chain: "zq",
           name: "Zilliqa",
           tokenManagerAddress: "0x6D61eFb60C17979816E4cE12CD5D29054E755948",
-          chainGatewayAddress: "0xE76669e1cCc150194eB92581baE79Ef6fa0E248E",
+          chainGatewayAddress: "0x71f3AD7cA177818399C9d79d74A6b284E4BEAAc9",
           tokenManagerType: TokenManagerType.LockAndRelease,
           wagmiChain: zilliqa,
           tokens: [
@@ -38,7 +38,7 @@ export const chainConfigs: Partial<Record<Chains, ChainConfig>> =
           name: "BSC",
           wagmiChain: bsc,
           tokenManagerAddress: "0xF391A1Ee7b3ccad9a9451D2B7460Ac646F899f23",
-          chainGatewayAddress: "0x2114e979b7CFDd8b358502e00f50Fd5f7787Fe63",
+          chainGatewayAddress: "0x3967f1a272Ed007e6B6471b942d655C802b42009",
           tokenManagerType: TokenManagerType.MintAndBurn,
           tokens: [
             {


### PR DESCRIPTION
Backwards compatible update on the abis.
Also migrates FE to use new chaingateway and validatormanager addresses
New mainnet contracts have also been added