### PR TITLE
DEVOPS-1298: registry cache in CI pipelines

### DIFF
--- a/.github/workflows/cicd-prd.yml
+++ b/.github/workflows/cicd-prd.yml
@@ -136,12 +136,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        application:
-          [
-            developer-portal,
-            devex,
-            zilliqa-isolated-server,
-          ]
+        application: [developer-portal, devex, zilliqa-isolated-server]
         include:
           - application: developer-portal
             image_name: developer-portal

--- a/.github/workflows/cicd-prd.yml
+++ b/.github/workflows/cicd-prd.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           context: ${{ matrix.path }}
           push: true
-          tag: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private/${{ matrix.image_name }}:${{ github.ref_name }}
+          tag: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public/${{ matrix.image_name }}:${{ github.ref_name }}
           registry: asia-docker.pkg.dev
           workload-identity-provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
           service-account: "${{ secrets.GCP_PRD_GITHUB_SA_DOCKER_REGISTRY }}"
@@ -155,7 +155,7 @@ jobs:
             tag_latest: true
     env:
       DOCKER_DOMAIN: asia-docker.pkg.dev
-      REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private
+      REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/cicd-prd.yml
+++ b/.github/workflows/cicd-prd.yml
@@ -23,8 +23,6 @@ jobs:
         application:
           [
             bluebell-playground,
-            developer-portal,
-            devex,
             devex-apollo,
             dev-wallet,
             faucet-service,
@@ -37,22 +35,11 @@ jobs:
             zillion,
             zilliqa-bridge-validator,
             zilliqa-bridge-web,
-            zilliqa-isolated-server,
           ]
         include:
           - application: bluebell-playground
             image_name: bluebell-playground
             path: products/bluebell
-            tag_length: 8
-            tag_latest: false
-          - application: developer-portal
-            image_name: developer-portal
-            path: products/developer-portal
-            tag_length: 8
-            tag_latest: false
-          - application: devex
-            image_name: devex
-            path: products/devex
             tag_length: 8
             tag_latest: false
           - application: devex-apollo
@@ -105,11 +92,6 @@ jobs:
             path: products/zillion
             tag_length: 8
             tag_latest: false
-          - application: zilliqa-isolated-server
-            image_name: zilliqa-isolated-server
-            path: products/zilliqa-isolated-server
-            tag_length: 8
-            tag_latest: true
           - application: zilliqa-bridge-validator
             image_name: zilliqa-bridge-validator
             path: products/bridge/bridge-validators
@@ -123,6 +105,62 @@ jobs:
     env:
       DOCKER_DOMAIN: asia-docker.pkg.dev
       REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Docker build and push - production
+        uses: Zilliqa/gh-actions-workflows/actions/ci-dockerized-app-build-push@v2
+        with:
+          context: ${{ matrix.path }}
+          push: true
+          tag: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private/${{ matrix.image_name }}:${{ github.ref_name }}
+          registry: asia-docker.pkg.dev
+          workload-identity-provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
+          service-account: "${{ secrets.GCP_PRD_GITHUB_SA_DOCKER_REGISTRY }}"
+          cache-key: ${{ env.REGISTRY }}/${{ matrix.image_name }}-cache
+          build-args: |
+            DEPLOY_ENV=prd
+
+  build-makefile:
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: ubuntu-22.04
+    name: "Build image with Makefile"
+    strategy:
+      fail-fast: false
+      matrix:
+        application:
+          [
+            developer-portal,
+            devex,
+            zilliqa-isolated-server,
+          ]
+        include:
+          - application: developer-portal
+            image_name: developer-portal
+            path: products/developer-portal
+            tag_length: 8
+            tag_latest: false
+          - application: devex
+            image_name: devex
+            path: products/devex
+            tag_length: 8
+            tag_latest: false
+          - application: zilliqa-isolated-server
+            image_name: zilliqa-isolated-server
+            path: products/zilliqa-isolated-server
+            tag_length: 8
+            tag_latest: true
+    env:
+      DOCKER_DOMAIN: asia-docker.pkg.dev
+      REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           context: ${{ matrix.path }}
           push: true # ${{ github.ref_name == github.event.repository.default_branch }}
-          tag: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private/${{ matrix.image_name }}
+          tag: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-public/${{ matrix.image_name }}
           tag-length: ${{ matrix.tag_length }}
           tag-latest: ${{ matrix.tag_latest }}
           registry: asia-docker.pkg.dev
@@ -149,7 +149,7 @@ jobs:
           #   tag_latest: true
     env:
       DOCKER_DOMAIN: asia-docker.pkg.dev
-      REGISTRY: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private
+      REGISTRY: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-public
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -16,83 +16,86 @@ jobs:
       id-token: write
       contents: write
     runs-on: ubuntu-22.04
-    # if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
+    if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
     name: "Deploy image"
     strategy:
       fail-fast: false
       matrix:
-        application: [
-            # devex-apollo,
-            # dev-wallet,
-            # faucet-service,
-            # governance-api,
-            # governance-snapshot,
-            # multisig,
-            # neo-savant,
-            # scilla-server,
+        application:
+          [
+            devex-apollo,
+            dev-wallet,
+            faucet-service,
+            governance-api,
+            governance-snapshot,
+            multisig,
+            neo-savant,
+            scilla-server,
             zillion,
+            zilliqa-bridge-validator,
+            zilliqa-bridge-web,
           ]
         include:
-          # - application: devex-apollo
-          #   image_name: devex-apollo
-          #   path: products/devex-apollo
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: dev-wallet
-          #   image_name: dev-wallet
-          #   path: products/dev-wallet
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: faucet-service
-          #   image_name: faucet-service
-          #   path: products/faucet-service
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: multisig
-          #   image_name: multisig
-          #   path: products/multisig
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: neo-savant
-          #   image_name: neo-savant
-          #   path: products/neo-savant
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: governance-api
-          #   image_name: governance-api
-          #   path: products/governance-api
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: governance-snapshot
-          #   image_name: governance-snapshot
-          #   path: products/governance-snapshot
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: pdt
-          #   image_name: pdt
-          #   path: products/pdt
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: scilla-server
-          #   image_name: scilla-server
-          #   path: products/scilla-server
-          #   tag_length: 8
-          #   tag_latest: false
+          - application: devex-apollo
+            image_name: devex-apollo
+            path: products/devex-apollo
+            tag_length: 8
+            tag_latest: false
+          - application: dev-wallet
+            image_name: dev-wallet
+            path: products/dev-wallet
+            tag_length: 8
+            tag_latest: false
+          - application: faucet-service
+            image_name: faucet-service
+            path: products/faucet-service
+            tag_length: 8
+            tag_latest: false
+          - application: multisig
+            image_name: multisig
+            path: products/multisig
+            tag_length: 8
+            tag_latest: false
+          - application: neo-savant
+            image_name: neo-savant
+            path: products/neo-savant
+            tag_length: 8
+            tag_latest: false
+          - application: governance-api
+            image_name: governance-api
+            path: products/governance-api
+            tag_length: 8
+            tag_latest: false
+          - application: governance-snapshot
+            image_name: governance-snapshot
+            path: products/governance-snapshot
+            tag_length: 8
+            tag_latest: false
+          - application: pdt
+            image_name: pdt
+            path: products/pdt
+            tag_length: 8
+            tag_latest: false
+          - application: scilla-server
+            image_name: scilla-server
+            path: products/scilla-server
+            tag_length: 8
+            tag_latest: false
           - application: zillion
             image_name: zillion
             path: products/zillion
             tag_length: 8
             tag_latest: false
-          # - application: zilliqa-bridge
-          #   image_name: zilliqa-bridge-validator
-          #   path: products/bridge/bridge-validators
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: zilliqa-bridge-web
-          #   image_name: zilliqa-bridge-web
-          #   path: products/bridge/bridge-web
-          #   tag_length: 8
-          #   tag_latest: false
+          - application: zilliqa-bridge
+            image_name: zilliqa-bridge-validator
+            path: products/bridge/bridge-validators
+            tag_length: 8
+            tag_latest: false
+          - application: zilliqa-bridge-web
+            image_name: zilliqa-bridge-web
+            path: products/bridge/bridge-web
+            tag_length: 8
+            tag_latest: false
     env:
       DOCKER_DOMAIN: asia-docker.pkg.dev
       REGISTRY: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-public
@@ -125,28 +128,28 @@ jobs:
       id-token: write
       contents: write
     runs-on: ubuntu-22.04
-    # if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
+    if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
     name: "Build image with Makefile"
     strategy:
       fail-fast: false
       matrix:
-        application: [developer-portal] #, devex, zilliqa-isolated-server]
+        application: [developer-portal, devex, zilliqa-isolated-server]
         include:
           - application: developer-portal
             image_name: developer-portal
             path: products/developer-portal
             tag_length: 8
             tag_latest: false
-          # - application: devex
-          #   image_name: devex
-          #   path: products/devex
-          #   tag_length: 8
-          #   tag_latest: false
-          # - application: zilliqa-isolated-server
-          #   image_name: zilliqa-isolated-server
-          #   path: products/zilliqa-isolated-server
-          #   tag_length: 8
-          #   tag_latest: true
+          - application: devex
+            image_name: devex
+            path: products/devex
+            tag_length: 8
+            tag_latest: false
+          - application: zilliqa-isolated-server
+            image_name: zilliqa-isolated-server
+            path: products/zilliqa-isolated-server
+            tag_length: 8
+            tag_latest: true
     env:
       DOCKER_DOMAIN: asia-docker.pkg.dev
       REGISTRY: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-public

--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -109,7 +109,7 @@ jobs:
         uses: Zilliqa/gh-actions-workflows/actions/ci-dockerized-app-build-push@v2
         with:
           context: ${{ matrix.path }}
-          push: ${{ github.ref_name == github.event.repository.default_branch }}
+          push: true # ${{ github.ref_name == github.event.repository.default_branch }}
           tag: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private/${{ matrix.image_name }}
           tag-length: ${{ matrix.tag_length }}
           tag-latest: ${{ matrix.tag_latest }}

--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -16,79 +16,78 @@ jobs:
       id-token: write
       contents: write
     runs-on: ubuntu-22.04
-    if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
+    # if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
     name: "Deploy image"
     strategy:
       fail-fast: false
       matrix:
-        application:
-          [
-            devex-apollo,
-            dev-wallet,
-            faucet-service,
-            governance-api,
-            governance-snapshot,
-            multisig,
-            neo-savant,
-            scilla-server,
+        application: [
+            # devex-apollo,
+            # dev-wallet,
+            # faucet-service,
+            # governance-api,
+            # governance-snapshot,
+            # multisig,
+            # neo-savant,
+            # scilla-server,
             zillion,
           ]
         include:
-          - application: devex-apollo
-            image_name: devex-apollo
-            path: products/devex-apollo
-            tag_length: 8
-            tag_latest: false
-          - application: dev-wallet
-            image_name: dev-wallet
-            path: products/dev-wallet
-            tag_length: 8
-            tag_latest: false
-          - application: faucet-service
-            image_name: faucet-service
-            path: products/faucet-service
-            tag_length: 8
-            tag_latest: false
-          - application: multisig
-            image_name: multisig
-            path: products/multisig
-            tag_length: 8
-            tag_latest: false
-          - application: neo-savant
-            image_name: neo-savant
-            path: products/neo-savant
-            tag_length: 8
-            tag_latest: false
-          - application: governance-api
-            image_name: governance-api
-            path: products/governance-api
-            tag_length: 8
-            tag_latest: false
-          - application: governance-snapshot
-            image_name: governance-snapshot
-            path: products/governance-snapshot
-            tag_length: 8
-            tag_latest: false
-          - application: pdt
-            image_name: pdt
-            path: products/pdt
-            tag_length: 8
-            tag_latest: false
-          - application: scilla-server
-            image_name: scilla-server
-            path: products/scilla-server
-            tag_length: 8
-            tag_latest: false
-          - application: zillion
-            image_name: zillion
-            path: products/zillion
-            tag_length: 8
-            tag_latest: false
-          - application: zilliqa-bridge
-            image_name: zilliqa-bridge-validator
-            path: products/bridge/bridge-validators
-            tag_length: 8
-            tag_latest: false
+          # - application: devex-apollo
+          #   image_name: devex-apollo
+          #   path: products/devex-apollo
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: dev-wallet
+          #   image_name: dev-wallet
+          #   path: products/dev-wallet
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: faucet-service
+          #   image_name: faucet-service
+          #   path: products/faucet-service
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: multisig
+          #   image_name: multisig
+          #   path: products/multisig
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: neo-savant
+          #   image_name: neo-savant
+          #   path: products/neo-savant
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: governance-api
+          #   image_name: governance-api
+          #   path: products/governance-api
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: governance-snapshot
+          #   image_name: governance-snapshot
+          #   path: products/governance-snapshot
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: pdt
+          #   image_name: pdt
+          #   path: products/pdt
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: scilla-server
+          #   image_name: scilla-server
+          #   path: products/scilla-server
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: zillion
+          #   image_name: zillion
+          #   path: products/zillion
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: zilliqa-bridge
+          #   image_name: zilliqa-bridge-validator
+          #   path: products/bridge/bridge-validators
+          #   tag_length: 8
+          #   tag_latest: false
           - application: zilliqa-bridge-web
             image_name: zilliqa-bridge-web
             path: products/bridge/bridge-web
@@ -126,33 +125,28 @@ jobs:
       id-token: write
       contents: write
     runs-on: ubuntu-22.04
-    if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
+    # if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
     name: "Build image with Makefile"
     strategy:
       fail-fast: false
       matrix:
-        application:
-          [
-            developer-portal,
-            devex,
-            zilliqa-isolated-server,
-          ]
+        application: [developer-portal] #, devex, zilliqa-isolated-server]
         include:
           - application: developer-portal
             image_name: developer-portal
             path: products/developer-portal
             tag_length: 8
             tag_latest: false
-          - application: devex
-            image_name: devex
-            path: products/devex
-            tag_length: 8
-            tag_latest: false
-          - application: zilliqa-isolated-server
-            image_name: zilliqa-isolated-server
-            path: products/zilliqa-isolated-server
-            tag_length: 8
-            tag_latest: true
+          # - application: devex
+          #   image_name: devex
+          #   path: products/devex
+          #   tag_length: 8
+          #   tag_latest: false
+          # - application: zilliqa-isolated-server
+          #   image_name: zilliqa-isolated-server
+          #   path: products/zilliqa-isolated-server
+          #   tag_length: 8
+          #   tag_latest: true
     env:
       DOCKER_DOMAIN: asia-docker.pkg.dev
       REGISTRY: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private

--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -112,7 +112,7 @@ jobs:
         uses: Zilliqa/gh-actions-workflows/actions/ci-dockerized-app-build-push@v2
         with:
           context: ${{ matrix.path }}
-          push: true # ${{ github.ref_name == github.event.repository.default_branch }}
+          push: ${{ github.ref_name == github.event.repository.default_branch }}
           tag: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-public/${{ matrix.image_name }}
           tag-length: ${{ matrix.tag_length }}
           tag-latest: ${{ matrix.tag_latest }}

--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -23,8 +23,6 @@ jobs:
       matrix:
         application:
           [
-            developer-portal,
-            devex,
             devex-apollo,
             dev-wallet,
             faucet-service,
@@ -34,19 +32,8 @@ jobs:
             neo-savant,
             scilla-server,
             zillion,
-            zilliqa-isolated-server,
           ]
         include:
-          - application: developer-portal
-            image_name: developer-portal
-            path: products/developer-portal
-            tag_length: 8
-            tag_latest: false
-          - application: devex
-            image_name: devex
-            path: products/devex
-            tag_length: 8
-            tag_latest: false
           - application: devex-apollo
             image_name: devex-apollo
             path: products/devex-apollo
@@ -97,11 +84,6 @@ jobs:
             path: products/zillion
             tag_length: 8
             tag_latest: false
-          - application: zilliqa-isolated-server
-            image_name: zilliqa-isolated-server
-            path: products/zilliqa-isolated-server
-            tag_length: 8
-            tag_latest: true
           - application: zilliqa-bridge
             image_name: zilliqa-bridge-validator
             path: products/bridge/bridge-validators
@@ -115,6 +97,65 @@ jobs:
     env:
       DOCKER_DOMAIN: asia-docker.pkg.dev
       REGISTRY: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-public
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: "true"
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Docker build and push - staging
+        uses: Zilliqa/gh-actions-workflows/actions/ci-dockerized-app-build-push@v2
+        with:
+          context: ${{ matrix.path }}
+          push: ${{ github.ref_name == github.event.repository.default_branch }}
+          tag: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private/${{ matrix.image_name }}
+          tag-length: ${{ matrix.tag_length }}
+          tag-latest: ${{ matrix.tag_latest }}
+          registry: asia-docker.pkg.dev
+          workload-identity-provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
+          service-account: "${{ secrets.GCP_STG_GITHUB_SA_DOCKER_REGISTRY }}"
+          cache-key: ${{ env.REGISTRY }}/${{ matrix.image_name }}-cache
+          build-args: |
+            DEPLOY_ENV=stg
+
+  build-makefile:
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: ubuntu-22.04
+    if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
+    name: "Build image with Makefile"
+    strategy:
+      fail-fast: false
+      matrix:
+        application:
+          [
+            developer-portal,
+            devex,
+            zilliqa-isolated-server,
+          ]
+        include:
+          - application: developer-portal
+            image_name: developer-portal
+            path: products/developer-portal
+            tag_length: 8
+            tag_latest: false
+          - application: devex
+            image_name: devex
+            path: products/devex
+            tag_length: 8
+            tag_latest: false
+          - application: zilliqa-isolated-server
+            image_name: zilliqa-isolated-server
+            path: products/zilliqa-isolated-server
+            tag_length: 8
+            tag_latest: true
+    env:
+      DOCKER_DOMAIN: asia-docker.pkg.dev
+      REGISTRY: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -78,21 +78,21 @@ jobs:
           #   path: products/scilla-server
           #   tag_length: 8
           #   tag_latest: false
-          # - application: zillion
-          #   image_name: zillion
-          #   path: products/zillion
-          #   tag_length: 8
-          #   tag_latest: false
+          - application: zillion
+            image_name: zillion
+            path: products/zillion
+            tag_length: 8
+            tag_latest: false
           # - application: zilliqa-bridge
           #   image_name: zilliqa-bridge-validator
           #   path: products/bridge/bridge-validators
           #   tag_length: 8
           #   tag_latest: false
-          - application: zilliqa-bridge-web
-            image_name: zilliqa-bridge-web
-            path: products/bridge/bridge-web
-            tag_length: 8
-            tag_latest: false
+          # - application: zilliqa-bridge-web
+          #   image_name: zilliqa-bridge-web
+          #   path: products/bridge/bridge-web
+          #   tag_length: 8
+          #   tag_latest: false
     env:
       DOCKER_DOMAIN: asia-docker.pkg.dev
       REGISTRY: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-public

--- a/products/multisig/Makefile
+++ b/products/multisig/Makefile
@@ -16,5 +16,5 @@ endif
 
 ## Build and push the Docker image
 image/build-and-push:
-	docker build --build-arg REACT_APP_DEPLOY_ENV=${ENVIRONMENT} -t "${IMAGE_TAG}" .
+	docker build -t "${IMAGE_TAG}" .
 	docker push "${IMAGE_TAG}"

--- a/products/zillion/Makefile
+++ b/products/zillion/Makefile
@@ -16,5 +16,5 @@ endif
 
 ## Build and push the Docker image
 image/build-and-push:
-	docker build --build-arg REACT_APP_DEPLOY_ENV=${ENVIRONMENT} -t "${IMAGE_TAG}" .
+	docker build -t "${IMAGE_TAG}" .
 	docker push "${IMAGE_TAG}"


### PR DESCRIPTION
- Registry Cache (v2) pipelines added to the CI pipelines.
- Removed unused variables from Makefiles of multisig and zillion.