### PR TITLE
DEVOPS-1298 bridge-validator ref in stg ci pipeline

### DIFF
--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -86,7 +86,7 @@ jobs:
             path: products/zillion
             tag_length: 8
             tag_latest: false
-          - application: zilliqa-bridge
+          - application: zilliqa-bridge-validator
             image_name: zilliqa-bridge-validator
             path: products/bridge/bridge-validators
             tag_length: 8


### PR DESCRIPTION
Name should match the matrix reference in a pipeline.