### PR TITLE
US-338: Revert "Bump h2 from 0.3.24 to 0.3.26 in /products/bridge/bridge-vali…

### DIFF
--- a/products/bridge/bridge-validators/Cargo.lock
+++ b/products/bridge/bridge-validators/Cargo.lock
@@ -1815,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
…dators (#639)"

This reverts commit 408458967bb9709b72f3c3534bbe48bd4db7bca6.