### PR TITLE
Revert "Bump eyre from 0.6.9 to 0.6.12 in /products/bridge/bridge-val…

### DIFF
--- a/products/bridge/bridge-validators/Cargo.lock
+++ b/products/bridge/bridge-validators/Cargo.lock
@@ -1497,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.12"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+checksum = "80f656be11ddf91bd709454d15d5bd896fbaf4cc3314e69349e4d1569f5b46cd"
 dependencies = [
  "indenter",
  "once_cell",


### PR DESCRIPTION
…idators (#636)"

This reverts commit a71c43e18722aa39974a9fdf12c86806a0141306.