### PR TITLE
DEVOPS-1369: update config.ts

### DIFF
--- a/products/bridge/bridge-web/src/config/config.ts
+++ b/products/bridge/bridge-web/src/config/config.ts
@@ -70,6 +70,12 @@ export const chainConfigs: Partial<Record<Chains, ChainConfig>> =
               blockExplorer:
                 "https://otterscan.testnet.zilliqa.com/address/0x8618d39a8276D931603c6Bc7306af6A53aD2F1F3",
             },
+            {
+              name: "TSLM",
+              address: "0xE90Dd366D627aCc5feBEC126211191901A69f8a0",
+              blockExplorer:
+                "https://otterscan.testnet.zilliqa.com/address/0xE90Dd366D627aCc5feBEC126211191901A69f8a0",
+            },
           ],
           chainId: 33101,
           isZilliqa: true,
@@ -89,6 +95,12 @@ export const chainConfigs: Partial<Record<Chains, ChainConfig>> =
               address: "0x5190e8b4Bbe8C3a732BAdB600b57fD42ACbB9F4B",
               blockExplorer:
                 "https://testnet.bscscan.com/address/0x5190e8b4Bbe8C3a732BAdB600b57fD42ACbB9F4B",
+            },
+            {
+              name: "TST",
+              address: "0x7Cc585de659E8938Aa7d5709BeaF34bD108bdC03",
+              blockExplorer:
+                "https://testnet.bscscan.com/address/0x7Cc585de659E8938Aa7d5709BeaF34bD108bdC03",
             },
           ],
           chainId: 97,


### PR DESCRIPTION
Adding test tokens deployed on ZQ and BSC testnets to the config to enable them in the x-bridge UI