### PR TITLE
APT-1040: build time staging decryption secrets added to CICD

### DIFF
--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -191,6 +191,8 @@ jobs:
         env:
           ENVIRONMENT: stg
           IMAGE_TAG: ${{ steps.set-tag.outputs.tags }}
+          ENV_FILES_DECRYPTER_NONPRD: ${{ secrets.ENV_FILES_DECRYPTER_NONPRD }}
+          ENV_FILES_DECRYPTER_PRD: ${{ secrets.ENV_FILES_DECRYPTER_PRD }}
         run: |
           cd ${{ matrix.path }}
           make image/build-and-push
@@ -200,6 +202,8 @@ jobs:
         env:
           ENVIRONMENT: stg
           IMAGE_TAG: "${{ env.REGISTRY }}/${{ matrix.image_name }}:latest"
+          ENV_FILES_DECRYPTER_NONPRD: ${{ secrets.ENV_FILES_DECRYPTER_NONPRD }}
+          ENV_FILES_DECRYPTER_PRD: ${{ secrets.ENV_FILES_DECRYPTER_PRD }}
         run: |
           cd ${{ matrix.path }}
           make image/build-and-push


### PR DESCRIPTION
# Description

Adding decryption secrets into the staging CICD.
Those secrets are already provided to prd pipeline https://github.com/Zilliqa/zilliqa-developer/blob/main/.github/workflows/cicd-prd.yml/#L202-L219