### PR TITLE
APT-1688: Logging for blockchain read access operations improved

### DIFF
--- a/products/zillion/src/saga/stakingSaga.ts
+++ b/products/zillion/src/saga/stakingSaga.ts
@@ -59,6 +59,7 @@ function* watchInitOnce() {
         if (isRespOk(totalCoinSupply)) {
             const totalCoinSupplyBN = new BigNumber(convertZilToQa(totalCoinSupply));
             circulatingSupplyStake = (new BigNumber(totalstakeamount).dividedBy(totalCoinSupplyBN)).times(100).toFixed(5);
+            console.log({totalCoinSupplyBN, totalstakeamount, circulatingSupplyStake});
         } else {
             // if total coin supply is not available, show loading so user hit refresh and try his luck with Zilliqa API again
             circulatingSupplyStake = 'Loading';


### PR DESCRIPTION
# Description

The web console now contains entries that start with `[BlockchainRead]`. For each blockchain read operation, there is one entry like that. It shows the query, how long it took, and whether it was successful.

# Testing

Works when running with `npm run dev`