### PR TITLE
APT-1689: Fix for _balance field in ZQ2 substate query response

### DIFF
--- a/products/zillion/cd/overlays/staging/kustomization.yaml
+++ b/products/zillion/cd/overlays/staging/kustomization.yaml
@@ -21,7 +21,7 @@ patches:
           kubernetes.io/ingress.global-static-ip-name: zillion-zilstg-dev
           networking.gke.io/managed-certificates: zillion
 
-- target:
+  - target:
       kind: ConfigMap
       name: zillion-config
     patch: |-

--- a/products/zillion/src/util/calculator.ts
+++ b/products/zillion/src/util/calculator.ts
@@ -36,6 +36,13 @@ export class RewardCalculator {
                 response = await this.contract.getSubState(key);
             }
 
+            // this is hack for ZQ2 returning _balance field for all substate queries
+            delete response?._balance;
+
+            if (Object.keys(response || {}).length === 0) {
+                response = null;
+            }
+
             printPerformance("Success");
             return response;
         } catch (err) {

--- a/products/zillion/src/util/reward-calculator.ts
+++ b/products/zillion/src/util/reward-calculator.ts
@@ -33,6 +33,7 @@ export const computeDelegRewards = async (impl: string, ssn: string, delegator: 
             result = await computeDelegRewardsExec(impl, zilliqa, ssn, delegator);
             break;
         } catch (err) {
+            console.error(`Error while calculating rewards. Attempt ${attempt + 1}\\${API_MAX_ATTEMPT}`, err);
             // error with querying api
             // retry
             continue;


### PR DESCRIPTION
# Description

Turns out, at least for now, the ZQ2 always returns `_balance` field in the response. Zillion reward calculation logic depends on the response being null if there is no data for given user.
Fixed by adjusting response before pushing it to the rewards logic.

Additionally, there was a minor bug in the deployment file.

# Testing

Run locally. Works on Mainnet and Protomainnet.