### PR TITLE
fix: DEVOPS-364 governance proposal creation 504 + stuck publish spinner

### DIFF
--- a/products/governance-api/cd/overlays/production/backendpolicy.yaml
+++ b/products/governance-api/cd/overlays/production/backendpolicy.yaml
@@ -3,6 +3,10 @@ kind: GCPBackendPolicy
 metadata:
   name: governance-api
 spec:
+  default:
+    # Proposal creation fetches + pins the full gZIL holder balances snapshot (~30s). Raise the
+    # backend timeout above GKE's 30s default so the request is not killed with a 504.
+    timeoutSec: 90
   targetRef:
     group: ""
     kind: Service

--- a/products/governance-api/cd/overlays/staging/backendpolicy.yaml
+++ b/products/governance-api/cd/overlays/staging/backendpolicy.yaml
@@ -3,6 +3,10 @@ kind: GCPBackendPolicy
 metadata:
   name: governance-api
 spec:
+  default:
+    # Proposal creation fetches + pins the full gZIL holder balances snapshot (~30s). Raise the
+    # backend timeout above GKE's 30s default so the request is not killed with a 504.
+    timeoutSec: 90
   targetRef:
     group: ""
     kind: Service

--- a/products/governance-api/lib/routes/message.ts
+++ b/products/governance-api/lib/routes/message.ts
@@ -244,7 +244,7 @@ message.post("/message", async (req, res) => {
 
       log.info({ token: base16Token, address: base16owner, userBalance }, "Zilliqa liquidity fetched");
 
-      const _balance = new BN(userBalance);
+      const _balance = new BN(userBalance || "0");
       const _minGZIL = new BN("30000000000000000");
 
       if (msg.token == gZIL && _balance.lt(_minGZIL)) {

--- a/products/governance-api/lib/zilliqa/custom-fetch.test.ts
+++ b/products/governance-api/lib/zilliqa/custom-fetch.test.ts
@@ -1,0 +1,85 @@
+// ABOUTME: Framework-free assertions for getLiquidity's submitter-scoped balance fetch.
+// ABOUTME: Run with `node --require ts-node/register lib/zilliqa/custom-fetch.test.ts`.
+import assert from "assert";
+import { blockchain } from "./custom-fetch";
+
+// The Scilla ZRC2 `balances` map is keyed by lowercase 0x addresses (verified against
+// api.zilliqa.com). getLiquidity must (a) fetch ONLY the submitter's entry — not the whole
+// multi-MB map — and (b) read it back with a normalized lowercase-0x key.
+
+async function scopedFetchTest() {
+  const b: any = new blockchain();
+  let sent: any;
+  b._send = async (batch: any[]) => {
+    sent = batch;
+    return [
+      { result: { pools: {} } },
+      { result: { balances: {} } },
+      { result: { xpools: {} } },
+      { result: { xbalances: {} } },
+      { result: { balances: { "0xabc": "123" } } },
+      { result: { total_supply: "1000" } },
+    ];
+  };
+
+  // Mixed-case inputs to prove normalization.
+  const out = await b.getLiquidity("0xA845c1034CD077bd8D32be0447239c7E4be6cb21", "0xABC");
+
+  assert.deepStrictEqual(
+    sent[4].params[2],
+    ["0xabc"],
+    "balances call must be scoped to the submitter (lowercase 0x), not the full map"
+  );
+  assert.notDeepStrictEqual(sent[4].params[2], [], "must NOT fetch the entire balances map");
+  assert.strictEqual(out.userBalance, "123", "userBalance read via normalized key");
+  console.log("OK scopedFetchTest");
+}
+
+async function nullResultTest() {
+  const b: any = new blockchain();
+  b._send = async () => [
+    { result: null },
+    { result: null },
+    { result: null },
+    { result: null },
+    { result: null },
+    { result: null },
+  ];
+  const out = await b.getLiquidity("0xA845c1034CD077bd8D32be0447239c7E4be6cb21", "0xfe56");
+  assert.strictEqual(out.userBalance, "0", "missing balance => '0' (no throw)");
+  assert.strictEqual(out.totalSupply, "0", "missing total_supply => '0' (no throw)");
+  console.log("OK nullResultTest");
+}
+
+async function lpHolderCreditedWithoutDirectBalance() {
+  // A submitter whose gZIL sits ONLY in ZilSwap liquidity (no direct balance entry) must still
+  // be credited via the seeded key. Without the seed this returns "0" and wrongly blocks them.
+  const b: any = new blockchain();
+  const TOKEN = "0xa845c1034cd077bd8d32be0447239c7e4be6cb21";
+  const OWNER = "0xabc"; // -> ownerKey "0xabc"
+  b._send = async () => [
+    { result: { pools: { [TOKEN]: { arguments: ["zilReserve", "1000000"] } } } },
+    { result: { balances: { [TOKEN]: { "0xabc": "50" } } } }, // owner = 100% of a 50-unit pool
+    { result: { xpools: {} } },
+    { result: { xbalances: {} } },
+    { result: { balances: {} } }, // NO direct token balance for the owner
+    { result: { total_supply: "999" } },
+  ];
+  const out = await b.getLiquidity(TOKEN, OWNER);
+  assert.strictEqual(
+    out.userBalance,
+    "1000000",
+    "LP-only holder must be credited their pool share via the seeded key"
+  );
+  console.log("OK lpHolderCreditedWithoutDirectBalance");
+}
+
+(async () => {
+  await scopedFetchTest();
+  await nullResultTest();
+  await lpHolderCreditedWithoutDirectBalance();
+  console.log("ALL PASS");
+})().catch((e) => {
+  console.error("FAIL:", e.message);
+  process.exit(1);
+});

--- a/products/governance-api/lib/zilliqa/custom-fetch.test.ts
+++ b/products/governance-api/lib/zilliqa/custom-fetch.test.ts
@@ -7,7 +7,11 @@ import { blockchain } from "./custom-fetch";
 // api.zilliqa.com). getLiquidity must (a) fetch ONLY the submitter's entry — not the whole
 // multi-MB map — and (b) read it back with a normalized lowercase-0x key.
 
-async function scopedFetchTest() {
+async function fullMapFetchTest() {
+  // The balances RPC MUST fetch the FULL holder map (index []): it is pinned to IPFS as the
+  // whole-electorate voter-scoring snapshot. Scoping it to the submitter collapses vote tallies
+  // to the submitter alone (regression C1). The submitter's own balance is still read back via a
+  // normalized lowercase-0x key (fixes a latent bech32 checksum mismatch).
   const b: any = new blockchain();
   let sent: any;
   b._send = async (batch: any[]) => {
@@ -17,22 +21,22 @@ async function scopedFetchTest() {
       { result: { balances: {} } },
       { result: { xpools: {} } },
       { result: { xbalances: {} } },
-      { result: { balances: { "0xabc": "123" } } },
+      { result: { balances: { "0xabc": "123", "0xdef": "999" } } },
       { result: { total_supply: "1000" } },
     ];
   };
 
-  // Mixed-case inputs to prove normalization.
+  // Mixed-case submitter input to prove read-key normalization.
   const out = await b.getLiquidity("0xA845c1034CD077bd8D32be0447239c7E4be6cb21", "0xABC");
 
   assert.deepStrictEqual(
     sent[4].params[2],
-    ["0xabc"],
-    "balances call must be scoped to the submitter (lowercase 0x), not the full map"
+    [],
+    "balances must fetch the FULL map (index []) for the voter-scoring snapshot (guards C1)"
   );
-  assert.notDeepStrictEqual(sent[4].params[2], [], "must NOT fetch the entire balances map");
-  assert.strictEqual(out.userBalance, "123", "userBalance read via normalized key");
-  console.log("OK scopedFetchTest");
+  assert.strictEqual(out.userBalance, "123", "submitter balance read via normalized lowercase key");
+  assert.ok("0xdef" in out.balances, "full electorate snapshot retained for scoring");
+  console.log("OK fullMapFetchTest");
 }
 
 async function nullResultTest() {
@@ -75,7 +79,7 @@ async function lpHolderCreditedWithoutDirectBalance() {
 }
 
 (async () => {
-  await scopedFetchTest();
+  await fullMapFetchTest();
   await nullResultTest();
   await lpHolderCreditedWithoutDirectBalance();
   console.log("ALL PASS");

--- a/products/governance-api/lib/zilliqa/custom-fetch.ts
+++ b/products/governance-api/lib/zilliqa/custom-fetch.ts
@@ -23,6 +23,9 @@ export class blockchain {
   private _zero = new BN(0);
 
   public async getLiquidity(token: string, address: string) {
+    // ZRC2 `balances` is keyed by lowercase 0x addresses; normalise the submitter's key so
+    // we can fetch ONLY their entry instead of downloading the entire (multi-MB) holder map.
+    const ownerKey = "0x" + this._toHex(address);
     const batch = [
       {
         method: RPCMethod.GetSmartContractSubState,
@@ -54,7 +57,7 @@ export class blockchain {
       },
       {
         method: RPCMethod.GetSmartContractSubState,
-        params: [this._toHex(token), TokenFields.Balances, []],
+        params: [this._toHex(token), TokenFields.Balances, [ownerKey]],
         id: 1,
         jsonrpc: `2.0`,
       },
@@ -72,13 +75,19 @@ export class blockchain {
       logger.error({ err, error_code: "ZILLIQA_RPC_FAILED" }, "Zilliqa RPC call failed");
       throw err;
     }
-    let tokenBalances = res[4]["result"][TokenFields.Balances];
-    const totalSupply = res[5]["result"][TokenFields.TotalSupply];
+    let tokenBalances = res[4]?.["result"]?.[TokenFields.Balances] ?? {};
+    const totalSupply = res[5]?.["result"]?.[TokenFields.TotalSupply] ?? "0";
+
+    // Seed the submitter's key so the LP crediting below can augment it even when the user
+    // holds no *direct* token balance (their gZIL may sit only in ZilSwap/XCAD liquidity).
+    if (!(ownerKey in tokenBalances)) {
+      tokenBalances[ownerKey] = "0";
+    }
 
     tokenBalances = this._parseZilSwap(res, token, tokenBalances);
     tokenBalances = this._parseXcad(res, token, tokenBalances);
 
-    const userBalance = tokenBalances[address];
+    const userBalance = tokenBalances[ownerKey] ?? "0";
 
     logger.info({ token, address, userBalance }, "Zilliqa liquidity fetched");
     return {
@@ -178,7 +187,7 @@ export class blockchain {
   }
 
   private _toHex(address: string) {
-    return String(address).replace("0x", "").toLowerCase();
+    return String(address).replace(/^0x/i, "").toLowerCase();
   }
 
   private async _send(batch: object[]) {

--- a/products/governance-api/lib/zilliqa/custom-fetch.ts
+++ b/products/governance-api/lib/zilliqa/custom-fetch.ts
@@ -23,8 +23,14 @@ export class blockchain {
   private _zero = new BN(0);
 
   public async getLiquidity(token: string, address: string) {
-    // ZRC2 `balances` is keyed by lowercase 0x addresses; normalise the submitter's key so
-    // we can fetch ONLY their entry instead of downloading the entire (multi-MB) holder map.
+    // Normalise the submitter's key (lowercase 0x, matching Scilla map keys) for the gate
+    // lookup + LP seeding below.
+    //
+    // NOTE: the FULL holder map is fetched on purpose (index [] below). It is pinned to IPFS
+    // as the whole-electorate voter-scoring snapshot (governance-snapshot get-scores.ts reads
+    // proposal.balances[voter]). Do NOT scope this to [ownerKey]: that shrinks the snapshot
+    // and collapses vote tallies to the submitter alone. The resulting ~30s fetch is covered
+    // by the raised gateway/client timeouts.
     const ownerKey = "0x" + this._toHex(address);
     const batch = [
       {
@@ -57,7 +63,7 @@ export class blockchain {
       },
       {
         method: RPCMethod.GetSmartContractSubState,
-        params: [this._toHex(token), TokenFields.Balances, [ownerKey]],
+        params: [this._toHex(token), TokenFields.Balances, []],
         id: 1,
         jsonrpc: `2.0`,
       },

--- a/products/governance-api/package.json
+++ b/products/governance-api/package.json
@@ -7,7 +7,8 @@
     "db:migrate": "npx sequelize db:migrate",
     "db:seed": "npx sequelize db:seed:all",
     "db:create": "npx sequelize db:create",
-    "start": "node --require ts-node/register index.ts"
+    "start": "node --require ts-node/register index.ts",
+    "test": "node --require ts-node/register lib/zilliqa/custom-fetch.test.ts"
   },
   "author": "Hicaru",
   "license": "MIT",

--- a/products/governance-snapshot/package.json
+++ b/products/governance-snapshot/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
     "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_SKIP_PROJECT=1 TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\",\"target\":\"es2019\",\"esModuleInterop\":true}' node --require ../governance-api/node_modules/ts-node/register src/helpers/client.test.ts"
   },
   "dependencies": {
     "@zilliqa-js/zilliqa": "3.5.0",

--- a/products/governance-snapshot/src/helpers/client.test.ts
+++ b/products/governance-snapshot/src/helpers/client.test.ts
@@ -1,0 +1,110 @@
+// ABOUTME: Framework-free assertions that client.request always settles (never hangs the UI).
+// ABOUTME: Run via ts-node transpile-only; mocks window + fetch. See command in the fix PR.
+import assert from "assert";
+
+(global as any).window = { VUE_APP_HUB_URL: "http://hub.test" };
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import client from "./client";
+
+async function nonJsonErrorDoesNotHang() {
+  // A gateway 504 returns an HTML body → res.json() throws. Must still reject, not hang.
+  (global as any).fetch = async () => ({
+    ok: false,
+    status: 504,
+    json: async () => {
+      throw new SyntaxError("Unexpected token < in JSON");
+    }
+  });
+  let rejected = false;
+  let val: any;
+  try {
+    await client.request("message", { a: 1 });
+  } catch (e) {
+    rejected = true;
+    val = e;
+  }
+  assert.strictEqual(rejected, true, "504 with non-JSON body must reject, not hang");
+  assert.ok(
+    val && typeof val.error_description === "string",
+    "rejection must carry a usable error_description"
+  );
+  console.log("OK nonJsonErrorDoesNotHang:", val.error_description);
+}
+
+async function successResolves() {
+  (global as any).fetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ ipfsHash: "Qm123" })
+  });
+  const out: any = await client.request("message", { a: 1 });
+  assert.deepStrictEqual(out, { ipfsHash: "Qm123" }, "success resolves to parsed JSON");
+  console.log("OK successResolves");
+}
+
+async function abortRejects() {
+  (global as any).fetch = async () => {
+    const e: any = new Error("aborted");
+    e.name = "AbortError";
+    throw e;
+  };
+  let rejected = false;
+  let val: any;
+  try {
+    await client.request("spaces");
+  } catch (e) {
+    rejected = true;
+    val = e;
+  }
+  assert.strictEqual(rejected, true, "abort/timeout must reject");
+  assert.ok(val.error_description.includes("timed out"), "AbortError => timeout message");
+  console.log("OK abortRejects:", val.error_description);
+}
+
+async function errorWithJsonRejectsServerObject() {
+  // A normal 400 (e.g. MIN_BALANCE) carries JSON the UI shows; reject with the server's object.
+  (global as any).fetch = async () => ({
+    ok: false,
+    status: 400,
+    json: async () => ({
+      code: 11,
+      error_description: "You require 30 $gZIL or more to submit a proposal."
+    })
+  });
+  let val: any;
+  try {
+    await client.request("message", { a: 1 });
+  } catch (e) {
+    val = e;
+  }
+  assert.strictEqual(val.code, 11, "rejects with the server's JSON error object");
+  assert.ok(val.error_description.includes("gZIL"), "preserves server error_description");
+  console.log("OK errorWithJsonRejectsServerObject");
+}
+
+async function successEmptyBodyResolves() {
+  // A 2xx with a non-JSON/empty body must resolve (to undefined), never hang or throw.
+  (global as any).fetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => {
+      throw new SyntaxError("empty body");
+    }
+  });
+  const out = await client.request("spaces");
+  assert.strictEqual(out, undefined, "non-JSON 2xx resolves to undefined");
+  console.log("OK successEmptyBodyResolves");
+}
+
+(async () => {
+  await nonJsonErrorDoesNotHang();
+  await successResolves();
+  await abortRejects();
+  await errorWithJsonRejectsServerObject();
+  await successEmptyBodyResolves();
+  console.log("ALL PASS");
+})().catch((e) => {
+  console.error("FAIL:", e.message);
+  process.exit(1);
+});

--- a/products/governance-snapshot/src/helpers/client.ts
+++ b/products/governance-snapshot/src/helpers/client.ts
@@ -1,7 +1,10 @@
 // ABOUTME: Thin fetch wrapper for the governance-api. Guarantees the returned promise always
 // ABOUTME: settles (timeout + defensive error parsing) so the UI never hangs on a 504/non-JSON.
 
-const REQUEST_TIMEOUT_MS = 45000;
+// Proposal creation pins the full gZIL holder snapshot (~30s); the gateway backend timeout is
+// raised to 90s to match, so keep this client ceiling just above it to surface a real 504
+// instead of aborting first. It is a safety net against an indefinitely hung backend.
+const REQUEST_TIMEOUT_MS = 95000;
 
 class Client {
   async request(command, body?) {
@@ -16,8 +19,7 @@ class Client {
       init.body = JSON.stringify(body);
     }
 
-    // Bound the request so a hung/slow backend (e.g. the gateway 504s at 30s) can never
-    // leave the caller waiting forever.
+    // Bound the request so a hung/slow backend can never leave the caller waiting forever.
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     init.signal = controller.signal;

--- a/products/governance-snapshot/src/helpers/client.ts
+++ b/products/governance-snapshot/src/helpers/client.ts
@@ -1,25 +1,55 @@
+// ABOUTME: Thin fetch wrapper for the governance-api. Guarantees the returned promise always
+// ABOUTME: settles (timeout + defensive error parsing) so the UI never hangs on a 504/non-JSON.
+
+const REQUEST_TIMEOUT_MS = 45000;
+
 class Client {
-  request(command, body?) {
+  async request(command, body?) {
     const url = `${window['VUE_APP_HUB_URL']}/api/${command}`;
-    let init;
+    const init: any = {};
     if (body) {
-      init = {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(body)
+      init.method = 'POST';
+      init.headers = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
       };
+      init.body = JSON.stringify(body);
     }
-    return new Promise((resolve, reject) => {
-      fetch(url, init)
-        .then(res => {
-          if (res.ok) return resolve(res.json());
-          throw res;
-        })
-        .catch(e => e.json().then(json => reject(json)));
-    });
+
+    // Bound the request so a hung/slow backend (e.g. the gateway 504s at 30s) can never
+    // leave the caller waiting forever.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    init.signal = controller.signal;
+
+    let res;
+    try {
+      res = await fetch(url, init);
+    } catch (e) {
+      // Network failure, CORS block, or abort (timeout). Reject with a usable shape.
+      const aborted = e && e.name === 'AbortError';
+      return Promise.reject({
+        error_description: aborted
+          ? 'Request timed out. Please try again.'
+          : 'Network error. Please try again.'
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    // Error responses are frequently NOT JSON (a gateway 504 returns an HTML page), so parse
+    // defensively instead of letting `res.json()` reject and strand the outer promise.
+    const payload = await res.json().catch(() => undefined);
+
+    if (res.ok) {
+      return payload;
+    }
+
+    return Promise.reject(
+      payload && typeof payload === 'object'
+        ? payload
+        : { error_description: `Request failed (HTTP ${res.status}).` }
+    );
   }
 }
 


### PR DESCRIPTION
## Problem

Users could not create proposals on the governance portal. Two distinct bugs, found by reproducing on staging and tracing the GCP logs:

1. **Backend 504.** `POST /api/message` calls `getLiquidity()`, which downloads the **entire gZIL ZRC2 `balances` map (~5 MB)** from `api.zilliqa.com` on every proposal. From the GKE cluster this takes **~30 s**, exceeding the gateway's 30 s `backend_timeout` -> **504**. Verified on staging:

   ```
   OPTIONS /api/message 200 (0.38s)
   POST    /api/message 504 (30.37s, backend_timeout)
   # app log: "Signature verified" -> 30s gap -> "Zilliqa liquidity fetched"
   ```

2. **Frontend infinite spinner.** `client.request` never settled its promise when the error body was not JSON (a 504 gateway HTML page) or the request was CORS-blocked (`e.json().then(json => reject(json))` left the outer promise pending). The publish spinner spun forever with no error shown.

## Changes

**`governance-api` - `lib/zilliqa/custom-fetch.ts`, `lib/routes/message.ts`, `cd/overlays/{staging,production}/backendpolicy.yaml`**
- **Fix the 504 by raising the backend timeout, not by shrinking the fetch.** The full `balances` map is fetched on purpose (`GetSmartContractSubState(..., "balances", [])`): it is pinned to IPFS as the **whole-electorate voter-scoring snapshot** that `governance-snapshot` reads via `get-scores.ts` (`proposal.balances[voter]`). `GCPBackendPolicy.spec.default.timeoutSec` is raised to **90 s** (staging + production) so the ~30 s fetch is no longer killed by GKE's 30 s default.
- Normalise the submitter's lookup key to lowercase `0x...` (Scilla state key format) for the MIN_BALANCE gate; also fixes a latent checksum mismatch for bech32/ZilPay addresses that previously made the gate read `undefined`.
- Seed the submitter's key before LP parsing so ZilSwap/XCAD liquidity is still credited toward the 30-gZIL gate when the user has no direct balance.
- Guard null RPC results; default missing balances to `"0"` (fail-closed gate).

**`governance-snapshot` - `src/helpers/client.ts`**
- Rewrite `request()` to always settle: `AbortController` (**95 s** timeout, just above the gateway's 90 s so a real 504 surfaces instead of the client aborting first), defensive JSON parsing, structured rejects (`{code, error_description}` or fallback). A 504/non-JSON now shows an error toast instead of hanging.

> **Note on the approach (PR review C1):** an earlier iteration scoped the balances fetch to the submitter (`[ownerKey]`, ~109 B / ~1.8 s) to fix the 504. That was reverted: the same `balances` object is pinned to IPFS and consumed by the frontend as the whole-electorate scoring oracle, so scoping it would have collapsed every new proposal's vote tally to the submitter alone. The 504 is addressed by the raised timeout instead, keeping the full snapshot intact. Caching the snapshot server-side is a sensible future optimisation as the holder set grows.

## Testing

Framework-free `node:assert` regression tests (the packages have no test runner), wired as `npm test` in both packages:
- `custom-fetch.test.ts`: `fullMapFetchTest` asserts the balances RPC fetches the **full map** (`params[2] == []`) and that the electorate snapshot is retained (a second holder survives), guarding C1; the submitter's balance is read back via the normalized lowercase key; LP-only holder credited via the seeded key; null result -> `"0"` without throwing.
- `client.test.ts`: rejects (no hang) on non-JSON 504; resolves on success; rejects with timeout on abort; preserves server JSON error; success-empty-body resolves.

Both suites pass (`npm test` in each package); both packages typecheck clean.

## Verify on staging

- ZilPay with >=30 gZIL -> proposal succeeds (`201`); proposal creation completes within the 90 s backend timeout (no 504).
- MetaMask on the gZIL space -> fast `400` MIN_BALANCE with a visible toast (no infinite spinner).

## Follow-ups (intentionally out of scope)

1. Pre-existing: `proposal()` / `vote()` are called without `await` and their early-return responses are discarded (`message.ts:229`); malformed proposals still hit the slow path and can double-send the response.
2. Product decision: EVM `0x` addresses hold no gZIL on Zilliqa, so MetaMask proposals on the gZIL space always hit MIN_BALANCE - decide on address mapping vs. restricting to ZilPay.
3. Logging: pino `level` is not mapped to Cloud Logging `severity`; 404s are logged at error level.
4. Performance: proposal creation re-fetches the full ~5 MB holder snapshot (~30 s) on every submission; consider caching/indexing it server-side as the holder set grows (the 90 s timeout is headroom, not a permanent fix). The `client.ts` 95 s ceiling is also global; a per-call timeout would keep fast-fail for metadata GETs.
