### PR TITLE
fix(governance-api): normalize EVM (MetaMask) submitters to their Zilliqa address

### DIFF
--- a/products/governance-api/lib/routes/message.ts
+++ b/products/governance-api/lib/routes/message.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import BN from "bn.js";
 import spaces from "@snapshot-labs/snapshot-spaces";
 import { verifySignature, pinJson } from "../utils";
-import { verifyEVMSignature } from "../utils/verify-evm-signature";
+import { verifyEVMSignature, zilliqaAddressFromEVMSignature } from "../utils/verify-evm-signature";
 import { Message } from "../models";
 import { blockchain } from "../zilliqa/custom-fetch";
 
@@ -225,6 +225,16 @@ message.post("/message", async (req, res) => {
     }
 
     log.info({ address: body.address, sigType: body.sigType || "schnorr" }, "Signature verified");
+
+    // EVM users sign with their 0x (Keccak) address, but their gZIL/ZRC2 balances and space
+    // membership are keyed by their Zilliqa (SHA256) address. Replace body.address with the
+    // canonical Zilliqa address recovered from the signature so the gZIL gate, the pinned
+    // voter-scoring snapshot, and the members/score checks all resolve against the user's real
+    // Zilliqa identity. Applies to both proposals and votes (same handler).
+    if (body.sigType === "evm") {
+      body.address = zilliqaAddressFromEVMSignature(body.sig.message, body.sig.signature);
+      log.info({ zilAddress: body.address }, "EVM identity normalized to Zilliqa address");
+    }
 
     proposal(res, msg);
     await vote(res, msg, ts, log);

--- a/products/governance-api/lib/utils/verify-evm-signature.test.ts
+++ b/products/governance-api/lib/utils/verify-evm-signature.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Asserts zilliqaAddressFromEVMSignature recovers the signer's canonical Zilliqa address.
+// ABOUTME: Run with `node --require ts-node/register lib/utils/verify-evm-signature.test.ts`.
+import assert from "assert";
+import { Wallet, SigningKey } from "ethers";
+import { getAddressFromPublicKey } from "@zilliqa-js/crypto";
+import {
+  zilliqaAddressFromEVMSignature,
+  verifyEVMSignature,
+} from "./verify-evm-signature";
+
+// A MetaMask user signs with their EVM (Keccak) address, but their gZIL/ZRC2 balances and
+// space membership live under their Zilliqa (SHA256) address. This proves we can recover the
+// Zilliqa address from the EVM personal_sign signature alone.
+
+async function derivesCanonicalZilliqaAddress() {
+  const pk = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+  const wallet = new Wallet(pk);
+  const message = JSON.stringify({ version: "0.1.2", type: "proposal", token: "duck" });
+  const signature = await wallet.signMessage(message); // EIP-191 personal_sign
+
+  // Ground truth derived straight from the private key (independent of the recovery path).
+  const expectedZil = getAddressFromPublicKey(
+    new SigningKey(pk).compressedPublicKey.replace(/^0x/, "")
+  );
+
+  const got = zilliqaAddressFromEVMSignature(message, signature);
+
+  assert.strictEqual(
+    got.toLowerCase(),
+    expectedZil.toLowerCase(),
+    "derives the signer's canonical Zilliqa address from the EVM signature"
+  );
+  assert.notStrictEqual(
+    got.toLowerCase(),
+    wallet.address.toLowerCase(),
+    "the Zilliqa address must differ from the EVM 0x address (the whole point)"
+  );
+  // The same signature still verifies against the EVM address (unchanged behaviour).
+  assert.strictEqual(
+    verifyEVMSignature(message, signature, wallet.address),
+    true,
+    "EVM signature still verifies against the EVM address"
+  );
+  console.log("OK derivesCanonicalZilliqaAddress:", got, "(EVM:", wallet.address + ")");
+}
+
+(async () => {
+  await derivesCanonicalZilliqaAddress();
+  console.log("ALL PASS");
+})().catch((e) => {
+  console.error("FAIL:", e.message);
+  process.exit(1);
+});

--- a/products/governance-api/lib/utils/verify-evm-signature.ts
+++ b/products/governance-api/lib/utils/verify-evm-signature.ts
@@ -1,4 +1,5 @@
-import { ethers } from 'ethers';
+import { ethers, hashMessage, SigningKey } from 'ethers';
+import { getAddressFromPublicKey } from '@zilliqa-js/crypto';
 
 /**
  * Verifies an EIP-191 personal_sign signature.
@@ -16,4 +17,25 @@ export function verifyEVMSignature(
   // Normalise both to lowercase hex without 0x for comparison
   const normalised = address.startsWith('0x') ? address.slice(2) : address;
   return recovered.slice(2).toLowerCase() === normalised.toLowerCase();
+}
+
+/**
+ * Derives the signer's canonical Zilliqa address (SHA256-based) from an EIP-191 personal_sign
+ * signature, by recovering the public key. This is the address ZilPay shows for the same key —
+ * i.e. where the user's gZIL/ZRC2 balances and space membership live. We use it to normalise an
+ * EVM (MetaMask) submitter to their Zilliqa identity so the gZIL gate, the pinned voter-scoring
+ * snapshot, and the members/score checks all resolve correctly.
+ *
+ * @param message   - The raw string passed to personal_sign (msg.msg from the request).
+ * @param signature - The 0x-prefixed hex signature returned by personal_sign.
+ * @returns The checksummed Zilliqa base16 address ("0x…").
+ */
+export function zilliqaAddressFromEVMSignature(
+  message: string,
+  signature: string
+): string {
+  const digest = hashMessage(message); // EIP-191 digest, matching personal_sign
+  const uncompressed = SigningKey.recoverPublicKey(digest, signature); // "0x04…"
+  const compressed = SigningKey.computePublicKey(uncompressed, true); // "0x02/03…"
+  return getAddressFromPublicKey(compressed.replace(/^0x/, ''));
 }

--- a/products/governance-api/package.json
+++ b/products/governance-api/package.json
@@ -8,7 +8,7 @@
     "db:seed": "npx sequelize db:seed:all",
     "db:create": "npx sequelize db:create",
     "start": "node --require ts-node/register index.ts",
-    "test": "node --require ts-node/register lib/zilliqa/custom-fetch.test.ts"
+    "test": "node --require ts-node/register lib/zilliqa/custom-fetch.test.ts && node --require ts-node/register lib/utils/verify-evm-signature.test.ts"
   },
   "author": "Hicaru",
   "license": "MIT",


### PR DESCRIPTION
## Problem

MetaMask (EVM) users are broken across every on-chain identity check. They sign with their **EVM `0x` address** (Keccak256-derived), but the governance checks all key off the user's **Zilliqa address** (SHA256-derived) — a *different* address for the same key:

- **30-gZIL gate** (`message.ts`): the EVM address holds no gZIL → always `MIN_BALANCE`.
- **Voter scoring** (`get-scores.ts` reads `proposal.balances[addr]`): the EVM voter isn't in the Zilliqa-keyed snapshot → score 0 → dropped from the tally.
- **Members / core tab** (`Proposals.vue`): `members` are `zil1…` (Zilliqa base16); an EVM author never matches.

## Fix

Recover the signer's **public key** from the EVM `personal_sign` signature, derive the **canonical Zilliqa address** (the one ZilPay shows for that key, where the user's gZIL/ZRC2 balances and membership live), and use it as the stored identity.

- `lib/utils/verify-evm-signature.ts`: add `zilliqaAddressFromEVMSignature()` — `hashMessage` → `SigningKey.recoverPublicKey` → compress → `getAddressFromPublicKey` (all from already-installed `ethers@6` + `@zilliqa-js/crypto`).
- `lib/routes/message.ts`: at the single `POST /api/message` choke point, **after** the EVM signature is verified, replace `body.address` with the derived Zilliqa address. Everything downstream (gZIL gate `getLiquidity`, IPFS pin, DB `Message.create`) then uses the real Zilliqa identity — for **both proposals and votes** (same handler).

No frontend changes: with the stored address now a real Zilliqa base16, the members compare, `toBech32Address` display, and scoring all line up.

## Scope / decisions
- **New submissions only** — no migration of pre-existing EVM-addressed records (there are likely none real, since MetaMask gZIL proposals never worked).
- **Identity model:** a MetaMask user is identified by their key's Zilliqa address. Caveat: it only sees gZIL held on *that* key's Zilliqa address — gZIL on a separate ZilPay account (different key) still won't count.
- **Known cosmetic limitation:** `User.vue` compares the stored address to the connected EVM account, so a MetaMask user may not see the "You" badge on their own items. Out of scope (would need a client-side Zilliqa-address derivation).

## Tests
- New `lib/utils/verify-evm-signature.test.ts`: signs with a fixed test key and asserts `zilliqaAddressFromEVMSignature(msg, sig)` equals the ground-truth `getAddressFromPublicKey(compress(pubkey))` and **differs** from the EVM address. Wired into `npm test` (now runs both suites; green).

## Security review
Reviewed (security-reviewer): **0 critical / 0 major.** Identity binding is sound — the Zilliqa address is derived from the *same* signature already verified against `body.address`, so a user can only obtain their own address; forging would require a valid secp256k1 signature for the target key. Crypto verified by round-trip; malformed signatures throw and are caught (→ 400).

**Pre-existing follow-up (not introduced here):** `body.sig.message` is never reconciled with `body.msg` on *either* the EVM or Schnorr path — a client can sign one string and submit a different proposal body. Worth a separate fix (assert `sig.message === body.msg`).

## Verify on staging
1. `npm test` green in `governance-api`.
2. With **MetaMask**, create a proposal on the **gZIL** space using a key whose **Zilliqa** address holds ≥30 gZIL → expect `201` (no `MIN_BALANCE`); confirm `GET /api/<space>/proposals` stored a `0x…` **Zilliqa** address (not the EVM one).
3. Vote from that MetaMask account → the vote appears in the tally with correct weight.
4. Logs show `"EVM identity normalized to Zilliqa address"` with the derived `zilAddress`.