### PR TITLE
fix(governance-snapshot): DEVOPS-376 bind submission to the wallet's active signer (Bearby "Address mismatch")

### DIFF
--- a/products/governance-api/lib/routes/message.ts
+++ b/products/governance-api/lib/routes/message.ts
@@ -31,21 +31,21 @@ const proposal = (res: any, msg: any) => {
   ) {
     return res.status(400).json({
       code: ErrorCodes.INCORRECT_PROPOSAL_FORMAT,
-      error_description: "incorect proposal format",
+      error_description: "incorrect proposal format",
     });
   }
 
   if (isNaN(msg.payload.snapshot) || Number(msg.payload.snapshot) === 0) {
     return res.status(400).json({
       code: ErrorCodes.INCORRECT_PROPOSAL_FORMAT,
-      error_description: "incorect snapshot blocknumber",
+      error_description: "incorrect snapshot blocknumber",
     });
   }
 
   if (!msg.payload.quorum || Number(msg.payload.quorum) > 100) {
     return res.status(400).json({
       code: ErrorCodes.INCORRECT_QUORUM,
-      error_description: "incorect quorum",
+      error_description: "incorrect quorum",
     });
   }
 
@@ -57,7 +57,7 @@ const proposal = (res: any, msg: any) => {
   ) {
     return res.status(400).json({
       code: ErrorCodes.INCORRECT_PROPOSAL_SIZE,
-      error_description: "incorect proposal size",
+      error_description: "incorrect proposal size",
     });
   }
 
@@ -67,7 +67,7 @@ const proposal = (res: any, msg: any) => {
   ) {
     return res.status(400).json({
       code: ErrorCodes.INCORRECT_PROPOSAL_METADATA,
-      error_description: "incorect proposal metadata",
+      error_description: "incorrect proposal metadata",
     });
   }
 
@@ -79,7 +79,7 @@ const proposal = (res: any, msg: any) => {
   ) {
     return res.status(400).json({
       code: ErrorCodes.INCORRECT_PROPOSAL_PERIOD,
-      error_description: "incorect proposal period",
+      error_description: "incorrect proposal period",
     });
   }
 };
@@ -96,7 +96,7 @@ const vote = async (res: any, msg: any, ts: string, log: any) => {
   ) {
     return res.status(400).json({
       code: ErrorCodes.INCORRECT_VOTE_FORMAT,
-      error_description: "incorect vote format",
+      error_description: "incorrect vote format",
     });
   }
 
@@ -106,7 +106,7 @@ const vote = async (res: any, msg: any, ts: string, log: any) => {
   ) {
     return res.status(400).json({
       code: ErrorCodes.INCORRECT_VOTE_METADATA,
-      error_description: "incorect vote metadata",
+      error_description: "incorrect vote metadata",
     });
   }
 
@@ -121,7 +121,7 @@ const vote = async (res: any, msg: any, ts: string, log: any) => {
     log.error({ error_code: ErrorCodes.INCORRECT_PROPOSAL_FORMAT, token: msg.token }, "Proposal not found");
     return res.status(400).json({
       code: ErrorCodes.INCORRECT_PROPOSAL_FORMAT,
-      error_description: "incorect vote proposal",
+      error_description: "incorrect vote proposal",
     });
   }
   const payload = JSON.parse(proposal.payload);
@@ -146,7 +146,7 @@ message.post("/message", async (req, res) => {
       log.error({ error_code: ErrorCodes.INCORRECT_DATA, address: body && body.address }, "incorrect message body");
       return res.status(400).json({
         code: ErrorCodes.INCORRECT_DATA,
-        error_description: "incorect message body",
+        error_description: "incorrect message body",
       });
     }
 

--- a/products/governance-api/lib/zilliqa/relayer.ts
+++ b/products/governance-api/lib/zilliqa/relayer.ts
@@ -10,7 +10,7 @@ zilliqa.wallet.addByPrivateKey(privateKey);
 const relayer = zilliqa.wallet.defaultAccount;
 
 if (!relayer) {
-  throw new Error("Incorect RELAYER_PK");
+  throw new Error("Incorrect RELAYER_PK");
 }
 
 export default relayer;

--- a/products/governance-snapshot/package.json
+++ b/products/governance-snapshot/package.json
@@ -6,7 +6,7 @@
     "serve": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
     "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_SKIP_PROJECT=1 TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\",\"target\":\"es2019\",\"esModuleInterop\":true}' node --require ../governance-api/node_modules/ts-node/register src/helpers/client.test.ts"
+    "test": "for f in client account; do TS_NODE_TRANSPILE_ONLY=1 TS_NODE_SKIP_PROJECT=1 TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\",\"target\":\"es2019\",\"esModuleInterop\":true}' node --require ../governance-api/node_modules/ts-node/register src/helpers/$f.test.ts || exit 1; done"
   },
   "dependencies": {
     "@zilliqa-js/zilliqa": "3.5.0",

--- a/products/governance-snapshot/src/helpers/account.test.ts
+++ b/products/governance-snapshot/src/helpers/account.test.ts
@@ -1,0 +1,73 @@
+// ABOUTME: Unit tests for account.ts — the derived signer must equal getAddressFromPublicKey.
+// ABOUTME: Framework-free; run via ts-node (see the "test" script in package.json).
+import assert from 'assert';
+import { getAddressFromPublicKey, fromBech32Address } from '@zilliqa-js/crypto';
+import {
+  normalizeBase16,
+  addressesMatch,
+  toAccount,
+  toHex0x,
+  accountFromPublicKey
+} from './account';
+
+// Deterministic fixture (private key d96e…0aba):
+const PUB =
+  '03bfad0f0b53cff5213b5947f3ddd66acee8906aba3610c111915aecc84092e052';
+const GROUND_TRUTH = getAddressFromPublicKey(PUB); // 0x381f4008…caF796
+
+function normalize() {
+  assert.strictEqual(normalizeBase16('0xAbC123'), 'abc123');
+  assert.strictEqual(normalizeBase16('AbC123'), 'abc123');
+  assert.strictEqual(normalizeBase16(''), '');
+  assert.strictEqual(normalizeBase16(undefined), '');
+  console.log('OK normalize');
+}
+
+function matches() {
+  assert.strictEqual(
+    addressesMatch('0xAbc', 'abc'),
+    true,
+    '0x + case insensitive'
+  );
+  assert.strictEqual(addressesMatch('0xAbc', '0xdef'), false);
+  assert.strictEqual(addressesMatch('', '0xabc'), false, 'empty never matches');
+  assert.strictEqual(addressesMatch(undefined, undefined), false);
+  console.log('OK matches');
+}
+
+function signerEqualsBackendCheck() {
+  // The point of the fix: the address derived here must equal the backend's
+  // getAddressFromPublicKey(publicKey), so verify-signature.ts passes by construction.
+  const acc = accountFromPublicKey(PUB);
+  assert.strictEqual(
+    '0x' + acc.base16,
+    GROUND_TRUTH.toLowerCase(),
+    'signer base16 == getAddressFromPublicKey (the backend address check)'
+  );
+  assert.strictEqual(
+    fromBech32Address(acc.bech32).toLowerCase(),
+    GROUND_TRUTH.toLowerCase(),
+    'bech32 round-trips to the same address'
+  );
+  console.log('OK signerEqualsBackendCheck', acc.bech32);
+}
+
+function accountForm() {
+  const acc = toAccount('0xE1984B201376e5C82836d10166B8de4a5c0d2EfF');
+  assert.strictEqual(acc.base16, 'e1984b201376e5c82836d10166b8de4a5c0d2eff');
+  assert.ok(acc.bech32.startsWith('zil1'), 'bech32 produced');
+  assert.strictEqual(
+    toHex0x(acc),
+    '0xe1984b201376e5c82836d10166b8de4a5c0d2eff',
+    'toHex0x re-adds the 0x prefix to the normalised base16'
+  );
+  console.log('OK accountForm', acc.bech32);
+}
+
+(function run() {
+  normalize();
+  matches();
+  signerEqualsBackendCheck();
+  accountForm();
+  console.log('ALL PASS');
+})();

--- a/products/governance-snapshot/src/helpers/account.ts
+++ b/products/governance-snapshot/src/helpers/account.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Pure helpers to derive and compare the wallet account that actually signs a message.
+// ABOUTME: One place for address normalisation so msg.address always equals the real signer.
+import { getAddressFromPublicKey, toBech32Address } from '@zilliqa-js/crypto';
+
+export interface Account {
+  base16: string; // lowercase hex, no 0x prefix
+  bech32: string;
+}
+
+// Normalise any Zilliqa/EVM address to lowercase hex without the 0x prefix.
+export function normalizeBase16(address?: string | null): string {
+  if (!address) return '';
+  return String(address)
+    .replace(/^0x/i, '')
+    .toLowerCase();
+}
+
+// True only when both addresses are non-empty and refer to the same account.
+export function addressesMatch(a?: string | null, b?: string | null): boolean {
+  const na = normalizeBase16(a);
+  return na !== '' && na === normalizeBase16(b);
+}
+
+// Build a normalised { base16, bech32 } pair from any address form.
+export function toAccount(address: string): Account {
+  const base16 = normalizeBase16(address);
+  return { base16, bech32: toBech32Address('0x' + base16) };
+}
+
+// The 0x-prefixed lowercase hex form, the single owner of the "+0x" convention
+// used on the wire (msg.address) and for explorer links.
+export function toHex0x(account: Account): string {
+  return '0x' + account.base16;
+}
+
+// Derive the signer from a Schnorr signature's public key using the SAME
+// function the backend uses (getAddressFromPublicKey in verify-signature.ts),
+// so the backend's address check passes by construction.
+export function accountFromPublicKey(publicKey: string): Account {
+  return toAccount(getAddressFromPublicKey(publicKey));
+}

--- a/products/governance-snapshot/src/helpers/web3.ts
+++ b/products/governance-snapshot/src/helpers/web3.ts
@@ -5,25 +5,48 @@ import { decodeContenthash } from '@/helpers/content';
 import abi from '@/helpers/abi';
 import { zilliqa } from '@/helpers/zilliqa';
 import { fromBech32Address } from '@zilliqa-js/zilliqa';
-import { validation } from "@zilliqa-js/util";
+import { validation } from '@zilliqa-js/util';
+import { accountFromPublicKey, toAccount, Account } from '@/helpers/account';
 
 export async function resolveContent(provider, name) {
   const contentHash = await resolveENSContentHash(name, provider);
   return decodeContenthash(contentHash);
 }
 
-export async function signMessage(web3: any, msg: string) {
+export async function signMessage(
+  web3: any,
+  msg: string
+): Promise<{ sig: any; signer: Account }> {
   if (web3?.isEVM) {
-    // personal_sign (EIP-191) via window.ethereum
-    const accounts: string[] = await window['ethereum'].request({ method: 'eth_accounts' });
+    // Sign with the wallet's currently-selected account. eth_requestAccounts
+    // returns the active account (and re-prompts if the wallet is locked),
+    // so the address we pass to personal_sign matches what the wallet signs
+    // with — otherwise the wallet rejects with "Address mismatch".
+    const accounts: string[] = await window['ethereum'].request({
+      method: 'eth_requestAccounts'
+    });
+    if (!accounts || !accounts.length) {
+      throw new Error(
+        'No active account in your wallet. Unlock it and select an account, then try again.'
+      );
+    }
+    const signerAddress = accounts[0];
     const signature: string = await window['ethereum'].request({
       method: 'personal_sign',
-      params: [msg, accounts[0]]
+      params: [msg, signerAddress]
     });
-    return { message: msg, signature };
+    return {
+      sig: { message: msg, signature },
+      signer: toAccount(signerAddress)
+    };
   }
-  // ZilPay Schnorr signing (existing)
-  return await web3.wallet.sign(msg);
+  // ZilPay/Bearby Schnorr: the wallet signs with its active account; trust the
+  // returned public key as the source of truth for who actually signed.
+  const sig: any = await web3.wallet.sign(msg);
+  if (!sig || !sig.publicKey) {
+    throw new Error('Wallet did not return a public key for the signature.');
+  }
+  return { sig, signer: accountFromPublicKey(sig.publicKey) };
 }
 
 export async function getBlockNumber(): Promise<number> {
@@ -32,7 +55,7 @@ export async function getBlockNumber(): Promise<number> {
 
     return parseInt(chainInfo.result.NumTxBlocks);
   } catch (e) {
-    console.error("Error calling getBlockNumber ", e);
+    console.error('Error calling getBlockNumber ', e);
     return Promise.reject();
   }
 }

--- a/products/governance-snapshot/src/store/modules/app.ts
+++ b/products/governance-snapshot/src/store/modules/app.ts
@@ -5,6 +5,7 @@ import client from '@/helpers/client';
 import ipfs from '@/helpers/ipfs';
 import { formatProposal, formatProposals, formatSpace } from '@/helpers/utils';
 import { getBlockNumber, signMessage } from '@/helpers/web3';
+import { toHex0x } from '@/helpers/account';
 import { version } from '@/../package.json';
 
 const state = {
@@ -81,24 +82,33 @@ const actions = {
     commit('SET', { spaces });
     return spaces;
   },
-  send: async ({ commit, dispatch, rootState }, { space, token, type, payload }) => {
+  send: async ({ commit, dispatch }, { space, token, type, payload }) => {
     const auth = getInstance();
     commit('SEND_REQUEST');
     try {
-      const msg: any = {
-        address: rootState.web3.account.base16,
-        space,
-        msg: JSON.stringify({
-          version,
-          timestamp: (Date.now() / 1e3).toFixed(),
-          token,
-          type,
-          payload
-        })
-      };
       const sigType = auth.provider?.isEVM ? 'evm' : 'schnorr';
-      msg.sig = await signMessage(auth.web3, msg.msg);
-      msg.sigType = sigType;
+      const message = JSON.stringify({
+        version,
+        timestamp: (Date.now() / 1e3).toFixed(),
+        token,
+        type,
+        payload
+      });
+
+      // Sign first, then learn exactly which account signed. The wallet may use
+      // a different active account than the one connected, so bind the
+      // submission to the REAL signer (msg.address must match the signature the
+      // backend verifies) and let the web3 module adopt it as the session account.
+      const { sig, signer } = await signMessage(auth.web3, message);
+      await dispatch('reconcileSigner', signer);
+
+      const msg: any = {
+        address: toHex0x(signer),
+        space,
+        msg: message,
+        sig,
+        sigType
+      };
       const result = await client.request('message', msg);
       commit('SEND_SUCCESS');
       dispatch('notify', ['green', `Your ${type} is in!`]);

--- a/products/governance-snapshot/src/store/modules/web3.ts
+++ b/products/governance-snapshot/src/store/modules/web3.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { getInstance } from '@/helpers/plugins/LockPlugin';
 import store from '@/store';
 import config from '@/helpers/config';
-import { toBech32Address } from '@zilliqa-js/crypto';
+import { toAccount, addressesMatch, Account } from '@/helpers/account';
 
 let wsProvider;
 let auth;
@@ -84,23 +84,38 @@ const actions = {
       commit('LOGOUT');
     }
   },
+  // Adopt the account that actually signed as the session account. The wallet
+  // signs with its ACTIVE account, which can differ from the connected one
+  // (multiple accounts, or the account-change subscription never fired under
+  // the wallet's compat layer). Sync the session to the real signer and warn
+  // when it changed so the user sees who they are acting as.
+  reconcileSigner: ({ commit, dispatch, state }, signer: Account) => {
+    if (addressesMatch(signer.base16, state.account.base16)) return;
+    commit('HANDLE_ACCOUNTS_CHANGED', signer);
+    dispatch('notify', [
+      'yellow',
+      `Signing as ${signer.bech32.slice(0, 9)}…${signer.bech32.slice(
+        -4
+      )} — the account active in your wallet. Switch accounts in your wallet if this isn't who you meant to act as.`
+    ]);
+  },
   loadProvider: async ({ commit }) => {
     commit('LOAD_PROVIDER_REQUEST');
     try {
       if (auth.provider?.isEVM) {
         // EVM path — address is carried on the provider sentinel from EVMConnector.connect()
-        const base16 = auth.provider.address.slice(2).toLowerCase();
-        const bech32 = toBech32Address('0x' + base16);
+        const account = toAccount(auth.provider.address);
         commit('HANDLE_CHAIN_CHANGED', 'mainnet');
         commit('SET_IS_EVM', true);
-        commit('LOAD_PROVIDER_SUCCESS', { account: { base16, bech32 }, name: '0x' + base16 });
+        commit('LOAD_PROVIDER_SUCCESS', {
+          account,
+          name: '0x' + account.base16
+        });
 
         // Subscribe to future account changes (e.g. user switches wallet in MetaMask)
         window['ethereum'].on('accountsChanged', (accounts: string[]) => {
           if (accounts.length) {
-            const b16 = accounts[0].slice(2).toLowerCase();
-            const b32 = toBech32Address('0x' + b16);
-            commit('HANDLE_ACCOUNTS_CHANGED', { base16: b16, bech32: b32 });
+            commit('HANDLE_ACCOUNTS_CHANGED', toAccount(accounts[0]));
           } else {
             commit('LOGOUT');
           }


### PR DESCRIPTION
  ## Problem
  A gZIL holder on **Bearby (ZilPay 2.0)** reported **"Address mismatch"** when signing a vote/proposal. Account `zil1uxvykgqnwmjus2pk6yqkdwx7ffwq6thlc4u7fl` = `0xe1984B201376e5C82836d10166B8de4a5c0d2EfF`
  (holds ~3,800 gZIL at its EVM address).

  ## Root cause
  The portal set `msg.address` from the **connected/stored** account, but the wallet signs with whatever account is **currently active**. When they diverge (multiple accounts, or the account-change
  subscription not firing under Bearby's compat layer):
  - the backend rejects, because `getAddressFromPublicKey(publicKey)` (Schnorr) / EVM-recovered signer ≠ `msg.address` → `INCORRECT_SIGNATURE` (error_code 9). **9 such failures, 0 successes** in prod logs
  for this address; and
  - Bearby's EVM service throws **"Address mismatch"** client-side (`bearbywallet/bearby-extension` → `background/services/evm.ts`), so it never reaches the backend (no log at the reported timestamp).

  ## Fix (frontend only)
  Bind `msg.address` to the account that actually signs:
  - `signMessage()` returns `{ sig, signer }`. EVM signs with `eth_requestAccounts` (the active account) + `personal_sign`; Schnorr derives the signer from `sig.publicKey` via `getAddressFromPublicKey` —
  the same function the backend uses, so the address check passes by construction.
  - New `web3/reconcileSigner` action adopts the real signer as the session account and warns when it differs from the connected one.
  - `account.ts` centralises address normalisation (`normalizeBase16`, `addressesMatch`, `toAccount`, `toHex0x`, `accountFromPublicKey`) with unit tests.

  Backend verification and the #780 gate-at-signing-address model are untouched.

  ## Verification
  - `npm test` (incl. new `account.test.ts`: derived signer == backend `getAddressFromPublicKey`) green.
  - `yarn build` clean; eslint adds no new errors.
  - Security + architecture review: 0 critical / 0 major.
  - **Staging (please verify):** with a multi-account Bearby, connect as A, activate B, vote → expect success as the active account (warning shown), no "Address mismatch"; legacy ZilPay (Zilliqa) accounts
  still work.

  ## Notes
  - Separate/pre-existing: the backend does not bind `sig.message` to `body.msg` (tracked in #779); this change keeps them equal and does not worsen it.

